### PR TITLE
Fix: escape meta character in yaml

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 )
 
@@ -152,8 +153,8 @@ func (sd *sdAPI) validate(filePath string) (jobs, error) {
 		return nil, err
 	}
 
-	escapedYaml := strings.ReplaceAll(yaml, "\"", "\\\"")
-	body := fmt.Sprintf(`{"yaml": "%s"}`, strings.ReplaceAll(escapedYaml, "\n", "\\n"))
+	escapedYaml := strconv.Quote(yaml)
+	body := fmt.Sprintf(`{"yaml": %s}`, escapedYaml)
 
 	res, err := sd.request(http.MethodPost, fullpath.String(), strings.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
## Context
We fixed escape processing because it failed to escape meta characters.

## Objective
Use `strconv.Quote`

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
