### PR TITLE
feat: --artifacts-dir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ debug
 # mac
 .DS_Store
 
-artifacts
+sd-artifacts
 .sdlocal/

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -76,7 +76,7 @@ func newBuildCmd() *cobra.Command {
 			}
 			go logger.Run()
 
-			launch := launchNew(job, config, jobName, api.JWT())
+			launch := launchNew(job, config, jobName, api.JWT(), artifactsPath)
 
 			err = launch.Run()
 			if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,10 +19,11 @@ const (
 )
 
 var (
-	configNew   = config.New
-	apiNew      = screwdriver.New
-	buildLogNew = buildlog.New
-	launchNew   = launch.New
+	configNew    = config.New
+	apiNew       = screwdriver.New
+	buildLogNew  = buildlog.New
+	launchNew    = launch.New
+	artifactsDir = launch.ArtifactsDir
 )
 
 func newBuildCmd() *cobra.Command {
@@ -53,13 +54,18 @@ func newBuildCmd() *cobra.Command {
 			if err != nil {
 				logrus.Fatal(err)
 			}
+
 			sdYAMLPath := filepath.Join(cwd, "screwdriver.yaml")
 			job, err := api.Job(jobName, sdYAMLPath)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			artifactsPath := filepath.Join(cwd, launch.ArtifactsDir)
+			artifactsPath, err := filepath.Abs(artifactsDir)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
 			err = os.MkdirAll(artifactsPath, 0666)
 			if err != nil {
 				logrus.Fatal(err)
@@ -82,5 +88,12 @@ func newBuildCmd() *cobra.Command {
 			logger.Stop()
 		},
 	}
+
+	buildCmd.Flags().StringVar(
+		&artifactsDir,
+		"artifacts-dir",
+		launch.ArtifactsDir,
+		"Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR.")
+
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,6 +20,31 @@ func TestBuildCmd(t *testing.T) {
 		want := ""
 		assert.Equal(t, want, buf.String())
 		assert.Nil(t, err)
+		assert.Equal(t, "sd-artifacts", artifactsDir)
+	})
+
+	t.Run("Success build cmd with --artifacts-dir", func(t *testing.T) {
+		root := newBuildCmd()
+
+		dir, err := ioutil.TempDir("", "example")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.RemoveAll(dir)
+
+		artifactsDir := filepath.Join(dir, "sd-artifacts")
+
+		root.SetArgs([]string{"test", "--artifacts-dir", artifactsDir})
+		buf := bytes.NewBuffer(nil)
+		root.SetOut(buf)
+		err = root.Execute()
+		want := ""
+		assert.Equal(t, want, buf.String())
+		assert.Nil(t, err)
+
+		_, err = os.Stat(artifactsDir)
+		assert.Nil(t, err)
 	})
 
 	t.Run("Failed build cmd when too many args", func(t *testing.T) {
@@ -25,7 +53,15 @@ func TestBuildCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Error: accepts 1 arg(s), received 2\nUsage:\n  build [job name] [flags]\n\nFlags:\n  -h, --help   help for build\n\n"
+		want := `Error: accepts 1 arg(s), received 2
+Usage:
+  build [job name] [flags]
+
+Flags:
+      --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -h, --help                   help for build
+
+`
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})
@@ -37,7 +73,15 @@ func TestBuildCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Error: accepts 1 arg(s), received 0\nUsage:\n  build [job name] [flags]\n\nFlags:\n  -h, --help   help for build\n\n"
+		want := `Error: accepts 1 arg(s), received 0
+Usage:
+  build [job name] [flags]
+
+Flags:
+      --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -h, --help                   help for build
+
+`
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -66,7 +66,15 @@ func TestRootCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Error: accepts 1 arg(s), received 0\nUsage:\n  sd-local build [job name] [flags]\n\nFlags:\n  -h, --help   help for build\n\n"
+		want := `Error: accepts 1 arg(s), received 0
+Usage:
+  sd-local build [job name] [flags]
+
+Flags:
+      --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -h, --help                   help for build
+
+`
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -35,7 +35,7 @@ func setup() {
 	configNew = func(confPath string) (config.Config, error) { return config.Config{}, nil }
 	apiNew = func(url, token string) (screwdriver.API, error) { return mockAPI{}, nil }
 	buildLogNew = func(filepath string, writer io.Writer) (logger buildlog.Logger, err error) { return mockLogger{}, nil }
-	launchNew = func(job screwdriver.Job, config config.Config, jobName, jwt string) launch.Launcher {
+	launchNew = func(job screwdriver.Job, config config.Config, jobName, jwt, artifactsPath string) launch.Launcher {
 		return mockLaunch{}
 	}
 }

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -19,7 +19,7 @@ var execCommand = exec.Command
 
 const (
 	// ArtifactsDir is default artifact directory name
-	ArtifactsDir = "artifacts"
+	ArtifactsDir = "sd-artifacts"
 	// LogFile is default logfile name for build log
 	LogFile = "builds.log"
 	// The definition of "ScmHost" and "OrgRepo" is in "PipelineFromID" of "screwdriver/screwdriver_local.go"

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -66,7 +66,7 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 	environment := buildConfig.Environment[0]
 
 	srcDir := cwd
-	hostArtDir := filepath.Join(cwd, ArtifactsDir)
+	hostArtDir := buildConfig.ArtifactsPath
 	containerArtDir := environment["SD_ARTIFACTS_DIR"]
 	buildImage := buildConfig.Image
 	logfilePath := filepath.Join(containerArtDir, LogFile)

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -40,6 +40,7 @@ type buildConfig struct {
 	Steps         []screwdriver.Step     `json:"steps"`
 	Image         string                 `json:"-"`
 	JobName       string                 `json:"-"`
+	ArtifactsPath string                 `json:"-"`
 }
 
 const (
@@ -54,7 +55,7 @@ func mergeEnv(env, userEnv envVar) []envVar {
 	return []envVar{env}
 }
 
-func createBuildConfig(config config.Config, job screwdriver.Job, jobName, jwt string) buildConfig {
+func createBuildConfig(config config.Config, job screwdriver.Job, jobName, jwt, artifactsPath string) buildConfig {
 	defaultEnv := envVar{
 		"SD_TOKEN":         jwt,
 		"SD_ARTIFACTS_DIR": defaultArtDir,
@@ -74,15 +75,16 @@ func createBuildConfig(config config.Config, job screwdriver.Job, jobName, jwt s
 		Steps:         job.Steps,
 		Image:         job.Image,
 		JobName:       jobName,
+		ArtifactsPath: artifactsPath,
 	}
 }
 
 // New creates new Launcher interface.
-func New(job screwdriver.Job, config config.Config, jobName, jwt string) Launcher {
+func New(job screwdriver.Job, config config.Config, jobName, jwt, artifactsPath string) Launcher {
 	l := new(launch)
 
 	l.runner = newDocker(config.Launcher.Image, config.Launcher.Version)
-	l.buildConfig = createBuildConfig(config, job, jobName, jwt)
+	l.buildConfig = createBuildConfig(config, job, jobName, jwt, artifactsPath)
 
 	return l
 }

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -37,6 +37,7 @@ func newBuildConfig() buildConfig {
 		Steps:         job.Steps,
 		Image:         job.Image,
 		JobName:       "test",
+		ArtifactsPath: "sd-artifacts",
 	}
 }
 
@@ -56,7 +57,7 @@ func TestNew(t *testing.T) {
 
 		expectedBuildConfig := newBuildConfig()
 
-		launcher := New(job, config, "test", "testjwt")
+		launcher := New(job, config, "test", "testjwt", "sd-artifacts")
 		l, ok := launcher.(*launch)
 		assert.True(t, ok)
 		assert.Equal(t, expectedBuildConfig, l.buildConfig)
@@ -77,7 +78,7 @@ func TestNew(t *testing.T) {
 		expectedBuildConfig := newBuildConfig()
 		expectedBuildConfig.Environment[0]["SD_ARTIFACTS_DIR"] = "/sd/workspace/artifacts"
 
-		launcher := New(job, config, "test", "testjwt")
+		launcher := New(job, config, "test", "testjwt", "sd-artifacts")
 		l, ok := launcher.(*launch)
 		assert.True(t, ok)
 		assert.Equal(t, expectedBuildConfig, l.buildConfig)


### PR DESCRIPTION
## Context

add `--artifacts-dir` option described in [design doc](https://github.com/screwdriver-cd/screwdriver/blob/master/design/sd-local.md#user-content-options)
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Add options to the subcommand.
- Pass the arg to `launch` and `buildlog`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
[sd-local design](https://github.com/screwdriver-cd/screwdriver/blob/master/design/sd-local.md#user-content-options)

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
