### PR TITLE
fix: Always pull image

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -66,7 +66,7 @@ func newBuildCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			err = os.MkdirAll(artifactsPath, 0666)
+			err = os.MkdirAll(artifactsPath, 0777)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -47,15 +47,14 @@ func (d *docker) setupBin() error {
 	image := fmt.Sprintf("%s:%s", d.setupImage, d.setupImageVersion)
 	err = execCommand("docker", "pull", image).Run()
 	if err != nil {
-		return fmt.Errorf("failed to pull launcher image")
+		return fmt.Errorf("failed to pull launcher image %v", err)
 	}
 	cmd := execCommand("docker", "container", "run", "--rm", "-v", mount, image, "--entrypoint", "/bin/echo set up bin")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	err = cmd.Run()
-
 	if err != nil {
-		return fmt.Errorf("failed to prepare build scripts %v", err)
+		return fmt.Errorf("failed to prepare build scripts")
 	}
 
 	return nil

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -61,6 +61,7 @@ func TestSetupBin(t *testing.T) {
 		{"success", "SUCCESS_SETUP_BIN", nil},
 		{"failure volume create", "FAIL_CREATING_VOLUME", fmt.Errorf("failed to create docker volume")},
 		{"failure container run", "FAIL_CONTAINER_RUN", fmt.Errorf("failed to prepare build scripts")},
+		{"failure launcher image pull", "FAIL_LAUNCHER_PULL", fmt.Errorf("failed to pull launcher image exit status 1")},
 	}
 
 	for _, tt := range testCase {
@@ -89,7 +90,8 @@ func TestRunBuild(t *testing.T) {
 		expectError error
 	}{
 		{"success", "SUCCESS_RUN_BUILD", nil},
-		{"fail run build", "FAIL_BUILD_CONTAINER_RUN", fmt.Errorf("exit status 1")},
+		{"failure build run", "FAIL_BUILD_CONTAINER_RUN", fmt.Errorf("exit status 1")},
+		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL", fmt.Errorf("failed to pull user image exit status 1")},
 	}
 
 	for _, tt := range testCase {
@@ -139,10 +141,26 @@ func TestHelperProcess(t *testing.T) {
 		if subcmd == "volume" {
 			os.Exit(0)
 		}
+		if subcmd == "pull" {
+			os.Exit(0)
+		}
 		os.Exit(1)
 	case "SUCCESS_RUN_BUILD":
 		os.Exit(0)
 	case "FAIL_BUILD_CONTAINER_RUN":
+		if subcmd == "pull" {
+			os.Exit(0)
+		}
 		os.Exit(1)
+	case "FAIL_LAUNCHER_PULL":
+		if subcmd == "pull" {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "FAIL_BUILD_IMAGE_PULL":
+		if subcmd == "pull" {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	}
 }


### PR DESCRIPTION
## Context
If sd-local doesn't pull image, latest image may not be actual latest. Therefore we make sd-local to pull image before run build.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- pull launcher image
- pull build image
- fix artifact dir mode

<!-- What does this PR fix? What intentional changes will this PR make? -->

## Notes
I think it is better to add option not to pull build image. It is because sometime user want to run build with local docker image. 
If it is necessary, we will add this option to sd-local design with another PR.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
