### PR TITLE
feat(1314): Add env option

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -31,6 +31,7 @@ var (
 
 func newBuildCmd() *cobra.Command {
 	var srcURL string
+	var optionEnv map[string]string
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -112,6 +113,7 @@ func newBuildCmd() *cobra.Command {
 				ArtifactsPath: artifactsPath,
 				Memory:        memory,
 				SrcPath:       srcPath,
+				OptionEnv:     optionEnv,
 			}
 
 			launch := launchNew(option)
@@ -148,5 +150,14 @@ func newBuildCmd() *cobra.Command {
 		`Specify the source url to build.
 ex) git@github.com:<org>/<repo>.git[#<branch>]
     https://github.com/<org>/<repo>.git[#<branch>]`)
+
+	buildCmd.Flags().StringToStringVarP(
+		&optionEnv,
+		"env",
+		"e",
+		map[string]string{},
+		"Set key and value relationship which is set as environment variables of Build Container",
+	)
+
 	return buildCmd
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/joho/godotenv"
 	"github.com/mitchellh/go-homedir"
 	"github.com/screwdriver-cd/sd-local/buildlog"
 	"github.com/screwdriver-cd/sd-local/config"
@@ -27,11 +29,32 @@ var (
 	artifactsDir = launch.ArtifactsDir
 	memory       = ""
 	scmNew       = scm.New
+	osMkdirAll   = os.MkdirAll
 )
+
+func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
+	absEnvFilePath, err := filepath.Abs(envFilePath)
+	if err != nil {
+		return err
+	}
+
+	env, err := godotenv.Read(absEnvFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read env file in `%s`: %v", absEnvFilePath, err)
+	}
+
+	for k, v := range env {
+		if _, ok := (*optionEnv)[k]; !ok {
+			(*optionEnv)[k] = v
+		}
+	}
+	return nil
+}
 
 func newBuildCmd() *cobra.Command {
 	var srcURL string
 	var optionEnv map[string]string
+	var envFilePath string
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -39,6 +62,13 @@ func newBuildCmd() *cobra.Command {
 		Long:  `Run screwdriver build of the specified job name.`,
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			if envFilePath != "" {
+				err := mergeEnvFromFile(&optionEnv, envFilePath)
+				if err != nil {
+					logrus.Fatal(err)
+				}
+			}
+
 			homedir, err := homedir.Dir()
 			if err != nil {
 				logrus.Fatal(err)
@@ -95,7 +125,7 @@ func newBuildCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			err = os.MkdirAll(artifactsPath, 0777)
+			err = osMkdirAll(artifactsPath, 0777)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -158,6 +188,12 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		map[string]string{},
 		"Set key and value relationship which is set as environment variables of Build Container",
 	)
+
+	buildCmd.Flags().StringVar(
+		&envFilePath,
+		"env-file",
+		"",
+		"Path to config file of environment variables.")
 
 	return buildCmd
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -186,14 +186,14 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"env",
 		"e",
 		map[string]string{},
-		"Set key and value relationship which is set as environment variables of Build Container",
+		"Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>)",
 	)
 
 	buildCmd.Flags().StringVar(
 		&envFilePath,
 		"env-file",
 		"",
-		"Path to config file of environment variables.")
+		"Path to config file of environment variables. '.env' format file can be used.")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -7,9 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/screwdriver-cd/sd-local/config"
 	"github.com/screwdriver-cd/sd-local/launch"
-	"github.com/screwdriver-cd/sd-local/screwdriver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -68,8 +66,8 @@ func TestBuildCmd(t *testing.T) {
 			"foo":  "bar",
 		}
 
-		launchNew = func(job screwdriver.Job, config config.Config, jobName, jwt, artifactsPath string, optionEnv launch.EnvVar) launch.Launcher {
-			assert.Equal(t, expected, optionEnv)
+		launchNew = func(option launch.Option) launch.Launcher {
+			assert.Equal(t, expected, option.OptionEnv)
 			return mockLaunch{}
 		}
 
@@ -92,8 +90,8 @@ func TestBuildCmd(t *testing.T) {
 			"foo":  "bar",
 		}
 
-		launchNew = func(job screwdriver.Job, config config.Config, jobName, jwt, artifactsPath string, optionEnv launch.EnvVar) launch.Launcher {
-			assert.Equal(t, expected, optionEnv)
+		launchNew = func(option launch.Option) launch.Launcher {
+			assert.Equal(t, expected, option.OptionEnv)
 			return mockLaunch{}
 		}
 
@@ -117,8 +115,8 @@ func TestBuildCmd(t *testing.T) {
 			"baz":  "qux",
 		}
 
-		launchNew = func(job screwdriver.Job, config config.Config, jobName, jwt, artifactsPath string, optionEnv launch.EnvVar) launch.Launcher {
-			assert.Equal(t, expected, optionEnv)
+		launchNew = func(option launch.Option) launch.Launcher {
+			assert.Equal(t, expected, option.OptionEnv)
 			return mockLaunch{}
 		}
 

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -139,8 +139,8 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
-  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container (default [])
-      --env-file string        Path to config file of environment variables.
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
+      --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --src-url string         Specify the source url to build.
@@ -165,8 +165,8 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
-  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container (default [])
-      --env-file string        Path to config file of environment variables.
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
+      --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --src-url string         Specify the source url to build.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -73,6 +73,8 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container (default [])
+      --env-file string        Path to config file of environment variables.
   -h, --help                   help for build
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --src-url string         Specify the source url to build.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -38,6 +38,7 @@ func setup() {
 	launchNew = func(option launch.Option) launch.Launcher {
 		return mockLaunch{}
 	}
+	osMkdirAll = func(path string, filemode os.FileMode) error { return nil }
 }
 
 func TestMain(m *testing.M) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -73,8 +73,8 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
-  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container (default [])
-      --env-file string        Path to config file of environment variables.
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
+      --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --src-url string         Specify the source url to build.

--- a/cmd/testdata/test_env
+++ b/cmd/testdata/test_env
@@ -1,0 +1,2 @@
+hoge=fuga
+foo=bar

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/go-yaml/yaml v2.1.0+incompatible
+	github.com/joho/godotenv v1.3.0
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-yaml/yaml v2.1.0+incompatible/go.mod h1:w2MrLa16VYP0jy6N7M5kHaCkaL
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -27,11 +27,11 @@ type launch struct {
 	runner      runner
 }
 
-type envVar map[string]string
+type EnvVar map[string]string
 
 type buildConfig struct {
 	ID            int                    `json:"id"`
-	Environment   []envVar               `json:"environment"`
+	Environment   []EnvVar               `json:"environment"`
 	EventID       int                    `json:"eventId"`
 	JobID         int                    `json:"jobId"`
 	ParentBuildID []int                  `json:"parentBuildId"`
@@ -54,14 +54,14 @@ type Option struct {
 	ArtifactsPath string
 	Memory        string
 	SrcPath       string
-	OptionEnv     envVar
+	OptionEnv     EnvVar
 }
 
 const (
 	defaultArtDir = "/sd/workspace/artifacts"
 )
 
-func mergeEnv(env, userEnv, optionEnv envVar) []envVar {
+func mergeEnv(env, userEnv, optionEnv EnvVar) []EnvVar {
 	for k, v := range userEnv {
 		env[k] = v
 	}
@@ -69,11 +69,11 @@ func mergeEnv(env, userEnv, optionEnv envVar) []envVar {
 		env[k] = v
 	}
 
-	return []envVar{env}
+	return []EnvVar{env}
 }
 
 func createBuildConfig(option Option) buildConfig {
-	defaultEnv := envVar{
+	defaultEnv := EnvVar{
 		"SD_TOKEN":         option.JWT,
 		"SD_ARTIFACTS_DIR": defaultArtDir,
 		"SD_API_URL":       option.Config.APIURL,

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -54,14 +54,18 @@ type Option struct {
 	ArtifactsPath string
 	Memory        string
 	SrcPath       string
+	OptionEnv     envVar
 }
 
 const (
 	defaultArtDir = "/sd/workspace/artifacts"
 )
 
-func mergeEnv(env, userEnv envVar) []envVar {
+func mergeEnv(env, userEnv, optionEnv envVar) []envVar {
 	for k, v := range userEnv {
+		env[k] = v
+	}
+	for k, v := range optionEnv {
 		env[k] = v
 	}
 
@@ -75,7 +79,7 @@ func createBuildConfig(option Option) buildConfig {
 		"SD_API_URL":       option.Config.APIURL,
 		"SD_STORE_URL":     option.Config.StoreURL,
 	}
-	env := mergeEnv(defaultEnv, option.Job.Environment)
+	env := mergeEnv(defaultEnv, option.Job.Environment, option.OptionEnv)
 
 	return buildConfig{
 		ID:            0,

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -61,8 +61,8 @@ const (
 	defaultArtDir = "/sd/workspace/artifacts"
 )
 
-func mergeEnv(env, userEnv, optionEnv EnvVar) []EnvVar {
-	for k, v := range userEnv {
+func mergeEnv(env, jobEnv, optionEnv EnvVar) []EnvVar {
+	for k, v := range jobEnv {
 		env[k] = v
 	}
 	for k, v := range optionEnv {

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -22,7 +22,7 @@ func newBuildConfig(options ...func(b *buildConfig)) buildConfig {
 
 	b := buildConfig{
 		ID: 0,
-		Environment: []envVar{{
+		Environment: []EnvVar{{
 			"SD_ARTIFACTS_DIR": "/test/artifacts",
 			"SD_API_URL":       "http://api-test.screwdriver.cd",
 			"SD_STORE_URL":     "http://store-test.screwdriver.cd",


### PR DESCRIPTION
## Context
This PR makes `sd-local` enable to set environment variables.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Add `--env` and `--env-file` options.
- When both `--env` and `--env-file` options are used, we give priority to `--env` about environment variables used in both options.
<!-- What does this PR fix? What intentional changes will this PR make? -->


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
