### PR TITLE
feat(1314): add publish job to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,5 @@
 builds:
-  - binary: sd-cmd
+  - binary: sd-local
     goos:
       - linux
       - darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,13 @@
+builds:
+  - binary: sd-cmd
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+    env:
+      - CGO_ENABLED=0
+
+archives:
+  - format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,3 +13,16 @@ jobs:
             - gofmt: (! gofmt -d -s . | grep '^')
             - test: go test -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./... ./...
             - build: go build -a -o /dev/null
+
+    publish:
+        requires: [test]
+        steps:
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - get: go mod download
+            - tag: ./ci/git-tag.sh
+            - release: "curl -sL https://git.io/goreleaser | bash"
+        secrets:
+            # Pushing tags to Git
+            - GIT_KEY
+            # Pushing releases to GitHub
+            - GITHUB_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -13,6 +13,7 @@ jobs:
             - gofmt: (! gofmt -d -s . | grep '^')
             - test: go test -coverprofile=${SD_ARTIFACTS_DIR}/coverage.out -coverpkg=./... ./...
             - build: go build -a -o /dev/null
+            - test-release: "curl -sL https://git.io/goreleaser | bash -s -- --snapshot"
 
     publish:
         requires: [test]


### PR DESCRIPTION
## Context
To install sd-local, we have to use `go get`, but it's a littel hard to use for users who aren't familiar with go.

## Objective
This PR publish the binary of sd-local to github release.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
