### PR TITLE
fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ debug
 # mac
 .DS_Store
 
+# Generated while deploying
+/ci/
+
 # goreleaser
 /dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@ debug
 # mac
 .DS_Store
 
+# goreleaser
+/dist/
+
 sd-artifacts
 .sdlocal/


### PR DESCRIPTION
## Context
release step was failed because of `git is currently in a dirty state`
https://cd.screwdriver.cd/pipelines/4014/builds/174131/steps/release

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- ignore `./dist/` in `.gitignore` because `./dist/` directory is created by goreleaser.
- ignore `./ci/` in `.gitignore` because `./ci/` directory is created by `setup-ci` step.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
