### PR TITLE
fix: Ignore VERSION

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,8 @@ debug
 # goreleaser
 /dist/
 
+# git-tag.sh
+/VERSION
+
 sd-artifacts
 .sdlocal/


### PR DESCRIPTION
## Context
release step was failed because of `git is currently in a dirty state`
https://cd.screwdriver.cd/pipelines/4014/builds/174135/steps/release

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- ignore `./VERSION` in `.gitignore` because `./VERSION` directory is created by `tag` step.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
