### PR TITLE
Enable to display current command's version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,8 @@ builds:
       - amd64
     env:
       - CGO_ENABLED=0
+    ldflags:
+      - "-X github.com/screwdriver-cd/sd-local/cmd.version={{ .Version }}"
 
 archives:
   - format: binary

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ func Execute() error {
 	rootCmd.AddCommand(
 		newBuildCmd(),
 		config.NewConfigCmd(),
+		newVersionCmd(),
 	)
 	return rootCmd.Execute()
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+)
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Display command's version.",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintln(cmd.OutOrStdout(), version)
+		},
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -7,6 +7,8 @@ import (
 )
 
 var (
+	// version is embedded when building this command using ldflags.
+	// if nothing is embedded, version is "dev"
 	version = "dev"
 )
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionCmd(t *testing.T) {
+	t.Run("Success version cmd", func(t *testing.T) {
+		cmd := newVersionCmd()
+		buf := bytes.NewBuffer(nil)
+		cmd.SetOut(buf)
+		cmd.Execute()
+		assert.Equal(t, "dev\n", buf.String())
+	})
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -2,17 +2,45 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionCmd(t *testing.T) {
-	t.Run("Success version cmd", func(t *testing.T) {
-		cmd := newVersionCmd()
-		buf := bytes.NewBuffer(nil)
-		cmd.SetOut(buf)
-		cmd.Execute()
-		assert.Equal(t, "dev\n", buf.String())
-	})
+	cases := []struct {
+		name    string
+		version string
+		expect  string
+	}{
+		{
+			name:    "0.0.1 is embedded as version",
+			version: "0.0.1",
+			expect:  "0.0.1",
+		},
+		{
+			name:    "0.1.0 is embedded as version",
+			version: "0.1.0",
+			expect:  "0.1.0",
+		},
+		{
+			name:   "version is not embedded",
+			expect: "dev",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			tv := version
+			if c.version != "" {
+				version = c.version
+			}
+			defer func() { version = tv }()
+			cmd := newVersionCmd()
+			buf := bytes.NewBuffer(nil)
+			cmd.SetOut(buf)
+			cmd.Execute()
+			assert.Equal(t, fmt.Sprintf("%s\n", c.expect), buf.String())
+		})
+	}
 }


### PR DESCRIPTION
## Context
This command is expected to keep updating, so I thought it would be better for users to know the version.

## Objective
I added `version` subcommand.

The version is embedded when building.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
