### PR TITLE
feat(1314): Add --sudo option 

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -33,6 +33,7 @@ var (
 	memory       = ""
 	scmNew       = scm.New
 	osMkdirAll   = os.MkdirAll
+	useSudo      = false
 )
 
 func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
@@ -189,6 +190,7 @@ func newBuildCmd() *cobra.Command {
 				SrcPath:       srcPath,
 				OptionEnv:     optionEnv,
 				Meta:          meta,
+				UseSudo:       useSudo,
 			}
 
 			launch := launchNew(option)
@@ -252,6 +254,12 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"meta-file",
 		"",
 		"Path to the meta file. meta file is represented with JSON format.")
+
+	buildCmd.Flags().BoolVar(
+		&useSudo,
+		"sudo",
+		false,
+		"Use sudo command for container runtime.")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -26,6 +26,7 @@ Flags:
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
+      --sudo                   Use sudo command for container runtime.
 
 `
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -82,6 +82,7 @@ Flags:
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
+      --sudo                   Use sudo command for container runtime.
 
 `
 		assert.Equal(t, want, buf.String())

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -100,12 +100,11 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 }
 
 func (d *docker) execDockerCommand(args ...string) error {
-	cmd := (*exec.Cmd)(nil)
+	commands := append([]string{"docker"}, args...)
 	if d.useSudo {
-		cmd = execCommand("sudo", append([]string{"docker"}, args...)...)
-	} else {
-		cmd = execCommand("docker", args...)
+		commands = append([]string{"sudo"}, commands...)
 	}
+	cmd := execCommand(commands[0], commands[1:]...)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stderr = buf
 	err := cmd.Run()

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -14,6 +14,7 @@ type docker struct {
 	volume            string
 	setupImage        string
 	setupImageVersion string
+	useSudo           bool
 }
 
 var _ runner = (*docker)(nil)
@@ -29,30 +30,31 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
-func newDocker(setupImage, setupImageVer string) runner {
+func newDocker(setupImage, setupImageVer string, useSudo bool) runner {
 	return &docker{
 		volume:            "SD_LAUNCH_BIN",
 		setupImage:        setupImage,
 		setupImageVersion: setupImageVer,
+		useSudo:           useSudo,
 	}
 }
 
 func (d *docker) setupBin() error {
-	_ = execDockerCommand("volume", "rm", "--force", d.volume)
+	_ = d.execDockerCommand("volume", "rm", "--force", d.volume)
 
-	err := execDockerCommand("volume", "create", "--name", d.volume)
+	err := d.execDockerCommand("volume", "create", "--name", d.volume)
 	if err != nil {
 		return fmt.Errorf("failed to create docker volume: %v", err)
 	}
 
 	mount := fmt.Sprintf("%s:/opt/sd/", d.volume)
 	image := fmt.Sprintf("%s:%s", d.setupImage, d.setupImageVersion)
-	err = execDockerCommand("pull", image)
+	err = d.execDockerCommand("pull", image)
 	if err != nil {
 		return fmt.Errorf("failed to pull launcher image: %v", err)
 	}
 
-	err = execDockerCommand("container", "run", "--rm", "-v", mount, image, "--entrypoint", "/bin/echo set up bin")
+	err = d.execDockerCommand("container", "run", "--rm", "-v", mount, image, "--entrypoint", "/bin/echo set up bin")
 	if err != nil {
 		return fmt.Errorf("failed to prepare build scripts: %v", err)
 	}
@@ -77,7 +79,7 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 		return err
 	}
 
-	err = execDockerCommand("pull", buildImage)
+	err = d.execDockerCommand("pull", buildImage)
 	if err != nil {
 		return fmt.Errorf("failed to pull user image %v", err)
 	}
@@ -89,7 +91,7 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 		dockerCommandOptions = append([]string{fmt.Sprintf("-m%s", buildConfig.MemoryLimit)}, dockerCommandOptions...)
 	}
 
-	err = execDockerCommand(append(dockerCommandArgs, dockerCommandOptions...)...)
+	err = d.execDockerCommand(append(dockerCommandArgs, dockerCommandOptions...)...)
 	if err != nil {
 		return fmt.Errorf("failed to run build container: %v", err)
 	}
@@ -97,8 +99,13 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 	return nil
 }
 
-func execDockerCommand(args ...string) error {
-	cmd := execCommand("docker", args...)
+func (d *docker) execDockerCommand(args ...string) error {
+	cmd := (*exec.Cmd)(nil)
+	if d.useSudo {
+		cmd = execCommand("sudo", append([]string{"docker"}, args...)...)
+	} else {
+		cmd = execCommand("docker", args...)
+	}
 	buf := bytes.NewBuffer(nil)
 	cmd.Stderr = buf
 	err := cmd.Run()

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -37,9 +37,10 @@ func TestNewDocker(t *testing.T) {
 			volume:            "SD_LAUNCH_BIN",
 			setupImage:        "launcher",
 			setupImageVersion: "latest",
+			useSudo:           false,
 		}
 
-		d := newDocker("launcher", "latest")
+		d := newDocker("launcher", "latest", false)
 
 		assert.Equal(t, expected, d)
 	})
@@ -65,6 +66,40 @@ func TestSetupBin(t *testing.T) {
 		{"failure volume create", "FAIL_CREATING_VOLUME", fmt.Errorf("failed to create docker volume: exit status 1")},
 		{"failure container run", "FAIL_CONTAINER_RUN", fmt.Errorf("failed to prepare build scripts: exit status 1")},
 		{"failure launcher image pull", "FAIL_LAUNCHER_PULL", fmt.Errorf("failed to pull launcher image: exit status 1")},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFakeExecCommand(tt.id)
+			execCommand = c.execCmd
+			err := d.setupBin()
+
+			assert.Equal(t, tt.expectError, err)
+		})
+	}
+}
+
+func TestSetupBinWithSudo(t *testing.T) {
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	d := &docker{
+		volume:            "SD_LAUNCH_BIN",
+		setupImage:        "launcher",
+		setupImageVersion: "latest",
+		useSudo:           true,
+	}
+
+	testCase := []struct {
+		name        string
+		id          string
+		expectError error
+	}{
+		{"success", "SUCCESS_SETUP_BIN_SUDO", nil},
+		{"failure volume create", "FAIL_CREATING_VOLUME_SUDO", fmt.Errorf("failed to create docker volume: exit status 1")},
+		{"failure container run", "FAIL_CONTAINER_RUN_SUDO", fmt.Errorf("failed to prepare build scripts: exit status 1")},
+		{"failure launcher image pull", "FAIL_LAUNCHER_PULL_SUDO", fmt.Errorf("failed to pull launcher image: exit status 1")},
 	}
 
 	for _, tt := range testCase {
@@ -129,6 +164,58 @@ func TestRunBuild(t *testing.T) {
 	}
 }
 
+func TestRunBuildWithSudo(t *testing.T) {
+	defer func() {
+		execCommand = exec.Command
+	}()
+
+	d := &docker{
+		volume:            "SD_LAUNCH_BIN",
+		setupImage:        "launcher",
+		setupImageVersion: "latest",
+		useSudo:           true,
+	}
+
+	testCase := []struct {
+		name             string
+		id               string
+		expectError      error
+		expectedCommands []string
+		buildConfig      buildConfig
+	}{
+		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
+			[]string{
+				"docker pull node:12",
+				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
+			newBuildConfig()},
+		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
+			[]string{
+				"docker pull node:12",
+				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
+			newBuildConfig(func(b *buildConfig) {
+				b.MemoryLimit = "2GB"
+			})},
+		{"failure build run", "FAIL_BUILD_CONTAINER_RUN_SUDO", fmt.Errorf("failed to run build container: exit status 1"), []string{}, newBuildConfig()},
+		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL_SUDO", fmt.Errorf("failed to pull user image exit status 1"), []string{}, newBuildConfig()},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFakeExecCommand(tt.id)
+			execCommand = c.execCmd
+			err := d.runBuild(tt.buildConfig)
+			for i, expectedCommand := range tt.expectedCommands {
+				assert.True(t, strings.Contains(c.commands[i], expectedCommand), "expect %q \nbut got \n%q", expectedCommand, c.commands[i])
+			}
+			if tt.expectError != nil {
+				assert.Equal(t, tt.expectError.Error(), err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
@@ -150,13 +237,21 @@ func TestHelperProcess(t *testing.T) {
 
 	cmd, subcmd, args := args[0], args[1], args[2:]
 	_, _ = cmd, args
+	testCase := os.Getenv("GO_TEST_MODE")
+	if strings.Index(testCase, "SUDO") > 0 {
+		subcmd = args[0]
+	}
 
-	switch os.Getenv("GO_TEST_MODE") {
+	switch testCase {
 	case "":
 		os.Exit(1)
 	case "SUCCESS_SETUP_BIN":
 		os.Exit(0)
+	case "SUCCESS_SETUP_BIN_SUDO":
+		os.Exit(0)
 	case "FAIL_CREATING_VOLUME":
+		os.Exit(1)
+	case "FAIL_CREATING_VOLUME_SUDO":
 		os.Exit(1)
 	case "FAIL_CONTAINER_RUN":
 		if subcmd == "volume" {
@@ -166,9 +261,24 @@ func TestHelperProcess(t *testing.T) {
 			os.Exit(0)
 		}
 		os.Exit(1)
+	case "FAIL_CONTAINER_RUN_SUDO":
+		if subcmd == "volume" {
+			os.Exit(0)
+		}
+		if subcmd == "pull" {
+			os.Exit(0)
+		}
+		os.Exit(1)
 	case "SUCCESS_RUN_BUILD":
 		os.Exit(0)
+	case "SUCCESS_RUN_BUILD_SUDO":
+		os.Exit(0)
 	case "FAIL_BUILD_CONTAINER_RUN":
+		if subcmd == "pull" {
+			os.Exit(0)
+		}
+		os.Exit(1)
+	case "FAIL_BUILD_CONTAINER_RUN_SUDO":
 		if subcmd == "pull" {
 			os.Exit(0)
 		}
@@ -178,7 +288,17 @@ func TestHelperProcess(t *testing.T) {
 			os.Exit(1)
 		}
 		os.Exit(0)
+	case "FAIL_LAUNCHER_PULL_SUDO":
+		if subcmd == "pull" {
+			os.Exit(1)
+		}
+		os.Exit(0)
 	case "FAIL_BUILD_IMAGE_PULL":
+		if subcmd == "pull" {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "FAIL_BUILD_IMAGE_PULL_SUDO":
 		if subcmd == "pull" {
 			os.Exit(1)
 		}

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -186,12 +186,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
+				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
 			newBuildConfig()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
+				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
 			newBuildConfig(func(b *buildConfig) {
 				b.MemoryLimit = "2GB"
 			})},

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -185,12 +185,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 	}{
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
-				"docker pull node:12",
+				"sudo docker pull node:12",
 				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
 			newBuildConfig()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
-				"docker pull node:12",
+				"sudo docker pull node:12",
 				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
 			newBuildConfig(func(b *buildConfig) {
 				b.MemoryLimit = "2GB"

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -47,6 +47,7 @@ type buildConfig struct {
 	ArtifactsPath string             `json:"-"`
 	MemoryLimit   string             `json:"-"`
 	SrcPath       string             `json:"-"`
+	UseSudo       bool               `json:"-"`
 }
 
 // Option is option for launch New
@@ -60,6 +61,7 @@ type Option struct {
 	SrcPath       string
 	OptionEnv     EnvVar
 	Meta          Meta
+	UseSudo       bool
 }
 
 const (
@@ -107,7 +109,7 @@ func createBuildConfig(option Option) buildConfig {
 func New(option Option) Launcher {
 	l := new(launch)
 
-	l.runner = newDocker(option.Config.Launcher.Image, option.Config.Launcher.Version)
+	l.runner = newDocker(option.Config.Launcher.Image, option.Config.Launcher.Version, option.UseSudo)
 	l.buildConfig = createBuildConfig(option)
 
 	return l


### PR DESCRIPTION
## Context

Executing `sd-local build <job>` by a no-privileged user will fail by permission problems on the container runtime.
So, now they should use `sudo sd-local` and it causes to make `sd-artifacts` directory in the current directory by `root`.
Therefore this PR add `--sudo` option for executing the container runtime to avoid problems above.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- add `--sudo` option
  - If it is used, `sd-local` execute `docker` with `sudo` command.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/screwdriver#1314
https://github.com/screwdriver-cd/screwdriver/blob/master/design/sd-local.md#options
(After this PR is merged, we will fix the design doc.)

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
