### PR TITLE
fix: add version to env url

### DIFF
--- a/launch/launch.go
+++ b/launch/launch.go
@@ -2,13 +2,20 @@ package launch
 
 import (
 	"fmt"
+	"net/url"
 	"os/exec"
+	"path"
 
 	"github.com/screwdriver-cd/sd-local/config"
 	"github.com/screwdriver-cd/sd-local/screwdriver"
+	"github.com/sirupsen/logrus"
 )
 
-var lookPath = exec.LookPath
+var (
+	lookPath     = exec.LookPath
+	apiVersion   = "v4"
+	storeVersion = "v1"
+)
 
 type runner interface {
 	runBuild(buildConfig buildConfig) error
@@ -83,9 +90,26 @@ func createBuildConfig(option Option) buildConfig {
 	defaultEnv := EnvVar{
 		"SD_TOKEN":         option.JWT,
 		"SD_ARTIFACTS_DIR": defaultArtDir,
-		"SD_API_URL":       option.Config.APIURL,
-		"SD_STORE_URL":     option.Config.StoreURL,
 	}
+
+	a, err := url.Parse(option.Config.APIURL)
+	if err == nil {
+		a.Path = path.Join(a.Path, apiVersion)
+		defaultEnv["SD_API_URL"] = a.String()
+	} else {
+		logrus.Warn("SD_API_URL is invalid. It may cause errors")
+		defaultEnv["SD_API_URL"] = option.Config.APIURL
+	}
+
+	s, err := url.Parse(option.Config.StoreURL)
+	if err == nil {
+		s.Path = path.Join(s.Path, storeVersion)
+		defaultEnv["SD_STORE_URL"] = s.String()
+	} else {
+		logrus.Warn("SD_STORE_URL is invalid. It may cause errors")
+		defaultEnv["SD_STORE_URL"] = option.Config.StoreURL
+	}
+
 	env := mergeEnv(defaultEnv, option.Job.Environment, option.OptionEnv)
 
 	return buildConfig{

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -87,27 +87,29 @@ func mergeEnv(env, jobEnv, optionEnv EnvVar) []EnvVar {
 }
 
 func createBuildConfig(option Option) buildConfig {
-	defaultEnv := EnvVar{
-		"SD_TOKEN":         option.JWT,
-		"SD_ARTIFACTS_DIR": defaultArtDir,
-	}
+	apiURL, storeURL := option.Config.APIURL, option.Config.StoreURL
 
 	a, err := url.Parse(option.Config.APIURL)
 	if err == nil {
 		a.Path = path.Join(a.Path, apiVersion)
-		defaultEnv["SD_API_URL"] = a.String()
+		apiURL = a.String()
 	} else {
 		logrus.Warn("SD_API_URL is invalid. It may cause errors")
-		defaultEnv["SD_API_URL"] = option.Config.APIURL
 	}
 
 	s, err := url.Parse(option.Config.StoreURL)
 	if err == nil {
 		s.Path = path.Join(s.Path, storeVersion)
-		defaultEnv["SD_STORE_URL"] = s.String()
+		storeURL = s.String()
 	} else {
 		logrus.Warn("SD_STORE_URL is invalid. It may cause errors")
-		defaultEnv["SD_STORE_URL"] = option.Config.StoreURL
+	}
+
+	defaultEnv := EnvVar{
+		"SD_TOKEN":         option.JWT,
+		"SD_ARTIFACTS_DIR": defaultArtDir,
+		"SD_API_URL":       apiURL,
+		"SD_STORE_URL":     storeURL,
 	}
 
 	env := mergeEnv(defaultEnv, option.Job.Environment, option.OptionEnv)

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -24,8 +24,8 @@ func newBuildConfig(options ...func(b *buildConfig)) buildConfig {
 		ID: 0,
 		Environment: []EnvVar{{
 			"SD_ARTIFACTS_DIR": "/test/artifacts",
-			"SD_API_URL":       "http://api-test.screwdriver.cd",
-			"SD_STORE_URL":     "http://store-test.screwdriver.cd",
+			"SD_API_URL":       "http://api-test.screwdriver.cd/v4",
+			"SD_STORE_URL":     "http://store-test.screwdriver.cd/v1",
 			"SD_TOKEN":         "testjwt",
 			"FOO":              "foo",
 		}},


### PR DESCRIPTION
## Context
users cannot use `sd-cmd` with `sd-local`

```
$ sd-local build --src-url https://github.com/screwdriver-cd-test/command-example.git main
INFO[0000] Pulling the source code from https://github.com/screwdriver-cd-test/command-example.git...
INFO[0002] Prepare to start build...
sd-setup-launcher: Screwdriver Launcher information
sd-setup-launcher: Version:        v6.0.48
sd-setup-launcher: Pipeline:       #0
sd-setup-launcher: Job:            main
sd-setup-launcher: Build:          #0
sd-setup-launcher: Workspace Dir:  /sd/workspace
sd-setup-launcher: Checkout Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Source Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Artifacts Dir:  /sd/workspace/artifacts
validate: $ sd-cmd validate -f sd-command.yaml
validate: set -e && export PATH=$PATH:/opt/sd && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish EXIT;
validate: ERROR: Post failed:Screwdriver API 404 Not Found: Not Found
```

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- add api version to `SD_API_URL` and `SD_STORE_URL`
<!-- What does this PR fix? What intentional changes will this PR make? -->

- verified to work with this fixes
```
$ ./sd-local build --src-url https://github.com/screwdriver-cd-test/command-example.git main
INFO[0000] Pulling the source code from https://github.com/screwdriver-cd-test/command-example.git...
INFO[0003] Prepare to start build...
sd-setup-launcher: Screwdriver Launcher information
sd-setup-launcher: Version:        v6.0.48
sd-setup-launcher: Pipeline:       #0
sd-setup-launcher: Job:            main
sd-setup-launcher: Build:          #0
sd-setup-launcher: Workspace Dir:  /sd/workspace
sd-setup-launcher: Checkout Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Source Dir:     /sd/workspace/src/screwdriver.cd/sd-local/local-build
sd-setup-launcher: Artifacts Dir:  /sd/workspace/artifacts
validate: $ sd-cmd validate -f sd-command.yaml
validate: set -e && export PATH=$PATH:/opt/sd && finish() { EXITCODE=$?; tmpfile=/tmp/env_tmp; exportfile=/tmp/env_export; export -p | grep -vi "PS1=" > $tmpfile && mv $tmpfile $exportfile; echo $SD_STEP_ID $EXITCODE; } && trap finish EXIT;
validate: Validation completed successfully.
validate:
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
