### PR TITLE
feat(1314): Add --local option to build command

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -120,13 +120,13 @@ func newBuildCmd() *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			configBaseDir := cwd
+			configBaseDir, err := homedir.Dir()
+			if err != nil {
+				logrus.Fatal(err)
+			}
 
-			if !useLocalConfig {
-				configBaseDir, err = homedir.Dir()
-				if err != nil {
-					logrus.Fatal(err)
-				}
+			if useLocalConfig {
+				configBaseDir = cwd
 			}
 
 			sdlocalDir := filepath.Join(configBaseDir, ".sdlocal")

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -234,10 +234,14 @@ func TestBuildCmd(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		defFunc := configNew
 		configNew = func(path string) (config.Config, error) {
 			assert.Equal(t, cnfPath, path)
 			return config.Config{}, nil
 		}
+		defer func() {
+			configNew = defFunc
+		}()
 
 		err = root.Execute()
 		want := ""

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -20,6 +20,7 @@ Flags:
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
+      --local                  Run command with .sdlocal/config file in current directory.
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -226,7 +226,7 @@ func TestBuildCmd(t *testing.T) {
 
 		cnfDir := filepath.Join(cwd, ".sdlocal")
 		os.MkdirAll(cnfDir, 0777)
-		defer os.Remove(cnfDir)
+		defer os.RemoveAll(cnfDir)
 
 		cnfPath := filepath.Join(cnfDir, "config")
 		err = os.Link("./testdata/config", cnfPath)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -76,6 +76,7 @@ Flags:
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
+      --local                  Run command with .sdlocal/config file in current directory.
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.

--- a/cmd/testdata/config
+++ b/cmd/testdata/config
@@ -1,0 +1,6 @@
+api-url: api-url
+store-url: store-api-url
+token: dummy_token
+launcher:
+  version: latest
+  image: screwdrivercd/launcher


### PR DESCRIPTION
## Context
Add `--local` option to build command to use config file in current directory.

## Objective
Add `--local` option.

## References
https://github.com/screwdriver-cd/screwdriver/issues/1314
https://github.com/screwdriver-cd/screwdriver/blob/master/design/sd-local.md#options
(After this PR is merged, we will fix the design doc.)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
