### PR TITLE
feat: Cleanup process after execution

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -137,7 +137,7 @@ func newBuildCmd() *cobra.Command {
 			if srcURL != "" {
 				logrus.Infof("Pulling the source code from %s...", srcURL)
 
-				scm, err := scmNew(sdlocalDir, srcURL)
+				scm, err := scmNew(sdlocalDir, srcURL, useSudo)
 				if err != nil {
 					return err
 				}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -82,6 +82,8 @@ func newBuildCmd() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var err error
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
 
 			if envFilePath != "" {
 				err = mergeEnvFromFile(&optionEnv, envFilePath)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var (
 	cleaners []Cleaner
 )
 
+// Cleaner will post-process sd-local.
 type Cleaner interface {
 	Kill(os.Signal)
 	Clean()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,9 +65,5 @@ func Execute() error {
 		config.NewConfigCmd(),
 		newVersionCmd(),
 	)
-	err := rootCmd.Execute()
-	if err != nil {
-		return err
-	}
 	return rootCmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,22 @@
 package cmd
 
 import (
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/screwdriver-cd/sd-local/cmd/config"
 	"github.com/spf13/cobra"
 )
+
+var (
+	cleaners []Cleaner
+)
+
+type Cleaner interface {
+	Kill(os.Signal)
+	Clean()
+}
 
 func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
@@ -15,13 +28,46 @@ a mostly the same environment as Screwdriver.cd's`,
 	return rootCmd
 }
 
+func Kill(sig os.Signal) {
+	for _, v := range cleaners {
+		v.Kill(sig)
+	}
+}
+
+func CleanExit(code int) {
+	for _, v := range cleaners {
+		v.Clean()
+	}
+	os.Exit(code)
+}
+
 // Execute executes the root command.
 func Execute() error {
+	cleaners = make([]Cleaner, 0, 2)
+	defer CleanExit(1)
+
+	go func() {
+		quit := make(chan os.Signal)
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		for {
+			select {
+			case sig := <-quit:
+				Kill(sig)
+				CleanExit(1)
+				return
+			}
+		}
+	}()
+
 	rootCmd := newRootCmd()
 	rootCmd.AddCommand(
 		newBuildCmd(),
 		config.NewConfigCmd(),
 		newVersionCmd(),
 	)
+	err := rootCmd.Execute()
+	if err != nil {
+		return err
+	}
 	return rootCmd.Execute()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,13 +28,13 @@ a mostly the same environment as Screwdriver.cd's`,
 	return rootCmd
 }
 
-func Kill(sig os.Signal) {
+func kill(sig os.Signal) {
 	for _, v := range cleaners {
 		v.Kill(sig)
 	}
 }
 
-func CleanExit(code int) {
+func cleanExit(code int) {
 	for _, v := range cleaners {
 		v.Clean()
 	}
@@ -44,7 +44,7 @@ func CleanExit(code int) {
 // Execute executes the root command.
 func Execute() error {
 	cleaners = make([]Cleaner, 0, 2)
-	defer CleanExit(1)
+	defer cleanExit(1)
 
 	go func() {
 		quit := make(chan os.Signal)
@@ -52,8 +52,8 @@ func Execute() error {
 		for {
 			select {
 			case sig := <-quit:
-				Kill(sig)
-				CleanExit(1)
+				kill(sig)
+				cleanExit(1)
 				return
 			}
 		}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -31,6 +31,10 @@ func (mock mockLogger) Stop() {}
 
 func (mock mockLaunch) Run() error { return nil }
 
+func (mock mockLaunch) Kill(os.Signal) {}
+
+func (mock mockLaunch) Clean() {}
+
 func setup() {
 	configNew = func(confPath string) (config.Config, error) { return config.Config{}, nil }
 	apiNew = func(url, token string) (screwdriver.API, error) { return mockAPI{}, nil }

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -168,7 +168,7 @@ func (d *docker) waitProcess(done chan struct{}) {
 				}
 			}
 			if finish {
-				done <- struct{}{}
+				close(done)
 				break
 			}
 		}

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -165,6 +165,8 @@ func (d *docker) clean() {
 }
 
 func (d *docker) waitForProcess(cmds []*exec.Cmd) error {
+	// Reducing this value will make the test faster.
+	// However, be sure to specify a time when you can sufficiently confirm that the process is dead.
 	t := time.NewTicker(1 * time.Second)
 	const retryMax = 9
 	retryCnt := 0

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -114,10 +114,7 @@ func (d *docker) execDockerCommand(args ...string) error {
 	d.commands = append(d.commands, cmd)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stderr = buf
-	cmd.Stdout = buf
-	// tmp
 	err := cmd.Run()
-	io.Copy(os.Stdout, buf)
 	if err != nil {
 		io.Copy(os.Stderr, buf)
 		return err
@@ -126,15 +123,11 @@ func (d *docker) execDockerCommand(args ...string) error {
 }
 
 func (d *docker) kill(sig os.Signal, sudo bool) {
-	logrus.Info("SUDO?:", sudo)
 	for _, v := range d.commands {
 		var err error
 
-		logrus.Info("CMD:", v)
-
 		if sudo {
 			cmd := execCommand("sudo", "kill", fmt.Sprintf("-%v", signum(sig)), strconv.Itoa(v.Process.Pid))
-			logrus.Info("KILL CMD:", cmd)
 			err = cmd.Run()
 		} else {
 			err = v.Process.Signal(sig)

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -125,7 +125,7 @@ func (d *docker) execDockerCommand(args ...string) error {
 func (d *docker) kill(sig os.Signal, sudo bool) {
 	for _, v := range d.commands {
 		var err error
-		if v.ProcessState == nil {
+		if v.ProcessState != nil {
 			continue
 		}
 

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -101,7 +101,6 @@ func (d *docker) runBuild(buildConfig buildConfig) error {
 
 	err = d.execDockerCommand(append(dockerCommandArgs, dockerCommandOptions...)...)
 	if err != nil {
-
 		return fmt.Errorf("failed to run build container: %v", err)
 	}
 

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 )
 
 type docker struct {
@@ -40,8 +42,6 @@ func newDocker(setupImage, setupImageVer string, useSudo bool) runner {
 }
 
 func (d *docker) setupBin() error {
-	_ = d.execDockerCommand("volume", "rm", "--force", d.volume)
-
 	err := d.execDockerCommand("volume", "create", "--name", d.volume)
 	if err != nil {
 		return fmt.Errorf("failed to create docker volume: %v", err)
@@ -113,4 +113,11 @@ func (d *docker) execDockerCommand(args ...string) error {
 		return err
 	}
 	return nil
+}
+
+func (d *docker) clean() {
+	err := d.execDockerCommand("volume", "rm", "--force", d.volume)
+	if err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove volume: %v", err))
+	}
 }

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -125,6 +125,9 @@ func (d *docker) execDockerCommand(args ...string) error {
 func (d *docker) kill(sig os.Signal, sudo bool) {
 	for _, v := range d.commands {
 		var err error
+		if v.ProcessState == nil {
+			continue
+		}
 
 		if sudo {
 			cmd := execCommand("sudo", "kill", fmt.Sprintf("-%v", signum(sig)), strconv.Itoa(v.Process.Pid))

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -142,7 +142,7 @@ func (d *docker) kill(sig os.Signal, sudo bool) {
 	}
 
 	done := make(chan struct{}, 1)
-	go d.waitProcess(done)
+	go d.waitForProcess(done)
 	<-done
 }
 
@@ -154,8 +154,9 @@ func (d *docker) clean() {
 	}
 }
 
-func (d *docker) waitProcess(done chan struct{}) {
+func (d *docker) waitForProcess(done chan struct{}) {
 	t := time.NewTicker(1 * time.Second)
+L:
 	for {
 		select {
 		case <-t.C:
@@ -169,7 +170,7 @@ func (d *docker) waitProcess(done chan struct{}) {
 			}
 			if finish {
 				close(done)
-				break
+				break L
 			}
 		}
 	}

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -141,7 +141,7 @@ func (d *docker) kill(sig os.Signal, sudo bool) {
 		}
 	}
 
-	done := make(chan bool, 1)
+	done := make(chan struct{}, 1)
 	go d.waitProcess(done)
 	<-done
 }
@@ -154,7 +154,7 @@ func (d *docker) clean() {
 	}
 }
 
-func (d *docker) waitProcess(done chan bool) {
+func (d *docker) waitProcess(done chan struct{}) {
 	t := time.NewTicker(1 * time.Second)
 	for {
 		select {
@@ -168,7 +168,7 @@ func (d *docker) waitProcess(done chan bool) {
 				}
 			}
 			if finish {
-				done <- true
+				done <- struct{}{}
 				break
 			}
 		}

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -267,7 +267,7 @@ func TestDockerKill(t *testing.T) {
 
 		d.commands[0].Start()
 		go func() {
-			time.Sleep(waitForKillTime * 2)
+			time.Sleep(waitForKillTime)
 			d.mutex.Lock()
 			// For some reason, "ProcessState" is not changed in "Process.Signal" or "syscall.kill", so change "ProcessState" directly.
 			d.commands[0].ProcessState = &os.ProcessState{}
@@ -334,7 +334,10 @@ func TestDockerKill(t *testing.T) {
 
 		d.commands[0].Start()
 		go func() {
-			time.Sleep(waitForKillTime * 2)
+			time.Sleep(waitForKillTime)
+			d.mutex.Lock()
+			d.commands[0].ProcessState = &os.ProcessState{}
+			d.mutex.Unlock()
 		}()
 
 		d.kill(syscall.SIGINT)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -505,7 +505,7 @@ func TestHelperProcess(t *testing.T) {
 		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 		}
-	case "FAILED_TO_KILL":
+	case "FAIL_TO_KILL":
 		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 			os.Exit(0)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -347,7 +347,7 @@ func TestDockerKill(t *testing.T) {
 }
 
 func TestDockerClean(t *testing.T) {
-	t.Run("success to clean", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 		}()

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -229,7 +229,7 @@ func TestRunBuildWithSudo(t *testing.T) {
 }
 
 func TestDockerKill(t *testing.T) {
-	t.Run("success to kill process with no commands", func(t *testing.T) {
+	t.Run("success with no commands", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -38,6 +38,7 @@ func TestNewDocker(t *testing.T) {
 			setupImage:        "launcher",
 			setupImageVersion: "latest",
 			useSudo:           false,
+			commands:          make([]*exec.Cmd, 0, 10),
 		}
 
 		d := newDocker("launcher", "latest", false)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -365,7 +365,7 @@ func TestDockerClean(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.volume), c.commands[0])
 	})
 
-	t.Run("success to clean with sudo", func(t *testing.T) {
+	t.Run("success with sudo", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 		}()

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -288,7 +288,7 @@ func TestDockerKill(t *testing.T) {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)
 		}()
-		c := newFakeExecCommand("FAILED_TO_KILL")
+		c := newFakeExecCommand("FAIL_TO_KILL")
 		execCommand = c.execCmd
 		command := execCommand("sleep")
 		d := &docker{
@@ -328,7 +328,7 @@ func TestDockerKill(t *testing.T) {
 			setupImage:        "launcher",
 			setupImageVersion: "latest",
 			useSudo:           true,
-			commands:          []*exec.Cmd{execCommand("command")},
+			commands:          []*exec.Cmd{execCommand("sleep")},
 			mutex:             &sync.Mutex{},
 		}
 
@@ -496,11 +496,11 @@ func TestHelperProcess(t *testing.T) {
 		}
 		os.Exit(0)
 	case "SUCCESS_TO_KILL":
-		if subcmd == "command" || subcmd == "sleep" {
+		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 			os.Exit(0)
 		}
-		os.Exit(1)
+		os.Exit(0)
 	case "FAIL_TO_KILL":
 		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -383,7 +383,7 @@ func TestDockerClean(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("sudo docker volume rm --force %v", d.volume), c.commands[0])
 	})
 
-	t.Run("failed to clean", func(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -254,7 +254,7 @@ func TestDockerKill(t *testing.T) {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)
 		}()
-		c := newFakeExecCommand("SUCCESS_TO_KILL_DOCKER_CMD")
+		c := newFakeExecCommand("SUCCESS_TO_KILL")
 		execCommand = c.execCmd
 		d := &docker{
 			volume:            "SD_LAUNCH_BIN",
@@ -496,15 +496,11 @@ func TestHelperProcess(t *testing.T) {
 		}
 		os.Exit(0)
 	case "SUCCESS_TO_KILL":
-		if subcmd == "command" {
+		if subcmd == "command" || subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 			os.Exit(0)
 		}
-		os.Exit(0)
-	case "SUCCESS_TO_KILL_DOCKER_CMD":
-		if subcmd == "sleep" {
-			time.Sleep(fakeProcessLifeTime)
-		}
+		os.Exit(1)
 	case "FAIL_TO_KILL":
 		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -317,7 +317,7 @@ func TestDockerKill(t *testing.T) {
 		assert.True(t, strings.Contains(actual, expected), fmt.Sprintf("\nexpected: %s \nactual: %s\n", expected, actual))
 	})
 
-	t.Run("able to use sudo", func(t *testing.T) {
+	t.Run("success with sudo", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 		}()

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -283,7 +283,7 @@ func TestDockerKill(t *testing.T) {
 		assert.Equal(t, "", actual)
 	})
 
-	t.Run("failed to kill process", func(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -249,7 +249,7 @@ func TestDockerKill(t *testing.T) {
 		assert.Equal(t, "", buf.String())
 	})
 
-	t.Run("success to kill process", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		defer func() {
 			execCommand = exec.Command
 			logrus.SetOutput(os.Stderr)

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -20,11 +20,13 @@ var (
 type runner interface {
 	runBuild(buildConfig buildConfig) error
 	setupBin() error
+	clean()
 }
 
 // Launcher able to run local build
 type Launcher interface {
 	Run() error
+	Clean()
 }
 
 var _ (Launcher) = (*launch)(nil)
@@ -157,4 +159,8 @@ func (l *launch) Run() error {
 	}
 
 	return nil
+}
+
+func (l *launch) Clean() {
+	l.runner.clean()
 }

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path"
 
@@ -20,13 +21,13 @@ var (
 type runner interface {
 	runBuild(buildConfig buildConfig) error
 	setupBin() error
-	clean()
+	clean(os.Signal)
 }
 
 // Launcher able to run local build
 type Launcher interface {
 	Run() error
-	Clean()
+	Clean(os.Signal)
 }
 
 var _ (Launcher) = (*launch)(nil)
@@ -161,6 +162,6 @@ func (l *launch) Run() error {
 	return nil
 }
 
-func (l *launch) Clean() {
-	l.runner.clean()
+func (l *launch) Clean(sig os.Signal) {
+	l.runner.clean(sig)
 }

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -21,7 +21,7 @@ var (
 type runner interface {
 	runBuild(buildConfig buildConfig) error
 	setupBin() error
-	kill(os.Signal, bool)
+	kill(os.Signal)
 	clean()
 }
 
@@ -166,7 +166,7 @@ func (l *launch) Run() error {
 }
 
 func (l *launch) Kill(sig os.Signal) {
-	l.runner.kill(sig, l.buildConfig.UseSudo)
+	l.runner.kill(sig)
 }
 
 func (l *launch) Clean() {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -21,13 +21,15 @@ var (
 type runner interface {
 	runBuild(buildConfig buildConfig) error
 	setupBin() error
-	clean(os.Signal, bool)
+	kill(os.Signal, bool)
+	clean()
 }
 
 // Launcher able to run local build
 type Launcher interface {
 	Run() error
-	Clean(os.Signal)
+	Kill(os.Signal)
+	Clean()
 }
 
 var _ (Launcher) = (*launch)(nil)
@@ -163,6 +165,10 @@ func (l *launch) Run() error {
 	return nil
 }
 
-func (l *launch) Clean(sig os.Signal) {
-	l.runner.clean(sig, l.buildConfig.UseSudo)
+func (l *launch) Kill(sig os.Signal) {
+	l.runner.kill(sig, l.buildConfig.UseSudo)
+}
+
+func (l *launch) Clean() {
+	l.runner.clean()
 }

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -21,7 +21,7 @@ var (
 type runner interface {
 	runBuild(buildConfig buildConfig) error
 	setupBin() error
-	clean(os.Signal)
+	clean(os.Signal, bool)
 }
 
 // Launcher able to run local build
@@ -131,6 +131,7 @@ func createBuildConfig(option Option) buildConfig {
 		ArtifactsPath: option.ArtifactsPath,
 		MemoryLimit:   option.Memory,
 		SrcPath:       option.SrcPath,
+		UseSudo:       option.UseSudo,
 	}
 }
 
@@ -163,5 +164,5 @@ func (l *launch) Run() error {
 }
 
 func (l *launch) Clean(sig os.Signal) {
-	l.runner.clean(sig)
+	l.runner.clean(sig, l.buildConfig.UseSudo)
 }

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -132,7 +132,7 @@ func (m *mockRunner) clean() {
 	m.cleanCalledCount++
 }
 
-func (m *mockRunner) kill(os.Signal, bool) {
+func (m *mockRunner) kill(os.Signal) {
 	m.killCalledCount++
 }
 

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -122,6 +123,12 @@ func (m *mockRunner) runBuild(buildConfig buildConfig) error {
 
 func (m *mockRunner) setupBin() error {
 	return m.errorSetupBin
+}
+
+func (m *mockRunner) clean() {
+}
+
+func (m *mockRunner) kill(os.Signal, bool) {
 }
 
 func TestRun(t *testing.T) {

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/screwdriver-cd/sd-local/config"
@@ -113,8 +114,10 @@ func TestNew(t *testing.T) {
 }
 
 type mockRunner struct {
-	errorRunBuild error
-	errorSetupBin error
+	errorRunBuild    error
+	errorSetupBin    error
+	killCalledCount  int
+	cleanCalledCount int
 }
 
 func (m *mockRunner) runBuild(buildConfig buildConfig) error {
@@ -126,9 +129,11 @@ func (m *mockRunner) setupBin() error {
 }
 
 func (m *mockRunner) clean() {
+	m.cleanCalledCount++
 }
 
 func (m *mockRunner) kill(os.Signal, bool) {
+	m.killCalledCount++
 }
 
 func TestRun(t *testing.T) {
@@ -234,5 +239,43 @@ func TestRun(t *testing.T) {
 		err := launch.Run()
 
 		assert.Equal(t, fmt.Errorf("failed to run build: docker: Error response from daemon"), err)
+	})
+}
+
+func TestKill(t *testing.T) {
+	t.Run("success to call kill", func(t *testing.T) {
+		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		job := screwdriver.Job{}
+		_ = json.Unmarshal(buf, &job)
+
+		launch := launch{
+			buildConfig: newBuildConfig(),
+			runner: &mockRunner{
+				errorRunBuild: nil,
+				errorSetupBin: nil,
+			},
+		}
+		launch.Kill(syscall.SIGINT)
+		mRunner := launch.runner.(*mockRunner)
+		assert.Equal(t, 1, mRunner.killCalledCount)
+	})
+}
+
+func TestClean(t *testing.T) {
+	t.Run("success to call clean", func(t *testing.T) {
+		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		job := screwdriver.Job{}
+		_ = json.Unmarshal(buf, &job)
+
+		launch := launch{
+			buildConfig: newBuildConfig(),
+			runner: &mockRunner{
+				errorRunBuild: nil,
+				errorSetupBin: nil,
+			},
+		}
+		launch.Clean()
+		mRunner := launch.runner.(*mockRunner)
+		assert.Equal(t, 1, mRunner.cleanCalledCount)
 	})
 }

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -26,7 +26,8 @@ var (
 // SCM is able to fetch source code to build
 type SCM interface {
 	Pull() error
-	Clean(os.Signal)
+	Kill(os.Signal)
+	Clean()
 	LocalPath() string
 }
 
@@ -81,14 +82,16 @@ func (s *scm) Pull() error {
 	return nil
 }
 
-func (s *scm) Clean(sig os.Signal) {
+func (s *scm) Kill(sig os.Signal) {
 	for _, v := range s.commands {
 		err := v.Process.Signal(sig)
 		if err != nil {
 			logrus.Warn(fmt.Errorf("failed to stop process: %v", err))
 		}
 	}
+}
 
+func (s *scm) Clean() {
 	err := os.RemoveAll(s.LocalPath())
 	if err != nil {
 		logrus.Warn(fmt.Errorf("failed to remove local source directory: %w", err))

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -84,7 +84,7 @@ func (s *scm) Pull() error {
 
 func (s *scm) Kill(sig os.Signal) {
 	for _, v := range s.commands {
-		if v.ProcessState == nil {
+		if v.ProcessState != nil {
 			continue
 		}
 		err := v.Process.Signal(sig)

--- a/scm/scm.go
+++ b/scm/scm.go
@@ -84,6 +84,9 @@ func (s *scm) Pull() error {
 
 func (s *scm) Kill(sig os.Signal) {
 	for _, v := range s.commands {
+		if v.ProcessState == nil {
+			continue
+		}
 		err := v.Process.Signal(sig)
 		if err != nil {
 			logrus.Warn(fmt.Errorf("failed to stop process: %v", err))

--- a/scm/scm_test.go
+++ b/scm/scm_test.go
@@ -36,7 +36,7 @@ func TestNew(t *testing.T) {
 		baseDir := os.TempDir()
 		srcURL := "https://github.com/screwdriver-cd/sd-local.git#test"
 
-		s, err := New(baseDir, srcURL)
+		s, err := New(baseDir, srcURL, false)
 		defer os.RemoveAll(s.LocalPath())
 
 		scm := s.(*scm)
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 		baseDir := os.TempDir()
 		srcURL := "git@github.com:screwdriver-cd/sd-local.git#branch#test"
 
-		s, err := New(baseDir, srcURL)
+		s, err := New(baseDir, srcURL, false)
 		defer os.RemoveAll(s.LocalPath())
 
 		scm := s.(*scm)
@@ -72,7 +72,7 @@ func TestNew(t *testing.T) {
 		baseDir := os.TempDir()
 		srcURL := "https://github.com/screwdriver-cd/sd-local.git#test"
 
-		s, err := New(baseDir, srcURL)
+		s, err := New(baseDir, srcURL, false)
 		msg := err.Error()
 
 		assert.Nil(t, s)
@@ -85,7 +85,7 @@ func TestNew(t *testing.T) {
 		baseDir := os.TempDir()
 		srcURL := "https://github.com/screwdriver-cd"
 
-		s, err := New(baseDir, srcURL)
+		s, err := New(baseDir, srcURL, false)
 
 		assert.Nil(t, s)
 		assert.Equal(t, err.Error(), "failed to fetch source code with invalid URL: https://github.com/screwdriver-cd")

--- a/scm/scm_test.go
+++ b/scm/scm_test.go
@@ -1,12 +1,17 @@
 package scm
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,6 +21,10 @@ type fakeExecCommand struct {
 	execCmd func(command string, args ...string) *exec.Cmd
 	command string
 }
+
+const (
+	fakeProcessLifeTime = 100 * time.Second
+)
 
 func newFakeExecCommand(id string) *fakeExecCommand {
 	c := &fakeExecCommand{}
@@ -107,6 +116,61 @@ func TestLocalPath(t *testing.T) {
 	})
 }
 
+func TestKill(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		defer func() {
+			execCommand = exec.Command
+			logrus.SetOutput(os.Stderr)
+		}()
+		c := newFakeExecCommand("SUCCESS_TO_KILL")
+		execCommand = c.execCmd
+		command := execCommand("command")
+		s := &scm{
+			commands: []*exec.Cmd{command},
+		}
+
+		s.commands[0].Start()
+
+		buf := bytes.NewBuffer(nil)
+		logrus.SetOutput(buf)
+
+		s.Kill(syscall.SIGINT)
+
+		actual := buf.String()
+		assert.Equal(t, "", actual)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		defer func() {
+			execCommand = exec.Command
+			logrus.SetOutput(os.Stderr)
+		}()
+		c := newFakeExecCommand("FAILED_TO_KILL")
+		execCommand = c.execCmd
+		command := execCommand("command")
+		s := &scm{
+			commands: []*exec.Cmd{command},
+		}
+
+		s.commands[0].Start()
+
+		PidTmp := s.commands[0].Process.Pid
+		defer func() {
+			syscall.Kill(PidTmp, syscall.SIGINT)
+		}()
+		s.commands[0].Process.Pid = 0
+
+		buf := bytes.NewBuffer(nil)
+		logrus.SetOutput(buf)
+
+		s.Kill(syscall.SIGINT)
+
+		actual := buf.String()
+		expected := "failed to stop process:"
+		assert.True(t, strings.Contains(actual, expected), fmt.Sprintf("\nexpected: %s \nactual: %s\n", expected, actual))
+	})
+}
+
 func TestClean(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		baseDir := os.TempDir()
@@ -129,6 +193,58 @@ func TestClean(t *testing.T) {
 		s.Clean()
 
 		assert.NoDirExists(t, s.LocalPath())
+	})
+
+	t.Run("success with sudo", func(t *testing.T) {
+		baseDir := os.TempDir()
+		defer func() {
+			os.RemoveAll(filepath.Join(baseDir, "repo"))
+			logrus.SetOutput(os.Stderr)
+		}()
+
+		c := newFakeExecCommand("SUCCESS_TO_CLEAN")
+		execCommand = c.execCmd
+		s := &scm{
+			baseDir:   baseDir,
+			remoteURL: "https://github.com/screwdriver-cd/sd-local.git",
+			branch:    "test",
+			localPath: filepath.Join(baseDir, "repo/test"),
+			sudo:      true,
+		}
+
+		buf := bytes.NewBuffer(nil)
+		logrus.SetOutput(buf)
+
+		s.Clean()
+
+		assert.Equal(t, "", buf.String())
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		baseDir := os.TempDir()
+		defer func() {
+			os.RemoveAll(filepath.Join(baseDir, "repo"))
+			logrus.SetOutput(os.Stderr)
+		}()
+
+		c := newFakeExecCommand("FAILURE_TO_CLEAN")
+		execCommand = c.execCmd
+		s := &scm{
+			baseDir:   baseDir,
+			remoteURL: "https://github.com/screwdriver-cd/sd-local.git",
+			branch:    "test",
+			localPath: filepath.Join(baseDir, "repo/test"),
+			sudo:      true,
+		}
+
+		buf := bytes.NewBuffer(nil)
+		logrus.SetOutput(buf)
+
+		s.Clean()
+
+		actual := buf.String()
+		expected := "failed to remove local source directory:"
+		assert.True(t, strings.Contains(actual, expected), fmt.Sprintf("\nexpected: %s\nactual: %s\n", expected, actual))
 	})
 }
 
@@ -209,6 +325,21 @@ func TestHelperProcess(t *testing.T) {
 	case "SUCCESS_PULL":
 		os.Exit(0)
 	case "FAILED_PULL":
+		os.Exit(1)
+	case "SUCCESS_TO_KILL":
+		if subcmd == "command" {
+			time.Sleep(fakeProcessLifeTime)
+			os.Exit(0)
+		}
+	case "FAIL_TO_KILL":
+		if subcmd == "command" {
+			time.Sleep(fakeProcessLifeTime)
+			os.Exit(0)
+		}
+		os.Exit(1)
+	case "SUCCESS_TO_CLEAN":
+		os.Exit(0)
+	case "FAILURE_TO_CLEAN":
 		os.Exit(1)
 	}
 }

--- a/scm/scm_test.go
+++ b/scm/scm_test.go
@@ -124,7 +124,7 @@ func TestKill(t *testing.T) {
 		}()
 		c := newFakeExecCommand("SUCCESS_TO_KILL")
 		execCommand = c.execCmd
-		command := execCommand("command")
+		command := execCommand("sleep")
 		s := &scm{
 			commands: []*exec.Cmd{command},
 		}
@@ -147,7 +147,7 @@ func TestKill(t *testing.T) {
 		}()
 		c := newFakeExecCommand("FAILED_TO_KILL")
 		execCommand = c.execCmd
-		command := execCommand("command")
+		command := execCommand("sleep")
 		s := &scm{
 			commands: []*exec.Cmd{command},
 		}
@@ -327,12 +327,12 @@ func TestHelperProcess(t *testing.T) {
 	case "FAILED_PULL":
 		os.Exit(1)
 	case "SUCCESS_TO_KILL":
-		if subcmd == "command" {
+		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 			os.Exit(0)
 		}
 	case "FAIL_TO_KILL":
-		if subcmd == "command" {
+		if subcmd == "sleep" {
 			time.Sleep(fakeProcessLifeTime)
 			os.Exit(0)
 		}


### PR DESCRIPTION
## Context
When "sd-local" completed or interrupted, the Docker volume, processes, etc. were not deleted and were not clean.
Fixed to remove Docker volume, processes, etc.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Added the following to the process:
- When interrupted:
  - It kills the process that was running.
  - Delete the docker volume
  - Delete the repository when using the `--src-url` option.
- When the execution is complete:
  - Delete the docker volume
  - Delete the repository when using the `--src-url` option.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
