### PR TITLE
Fix exit status and error message bug

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,17 +35,16 @@ func kill(sig os.Signal) {
 	}
 }
 
-func cleanExit(code int) {
+func clean() {
 	for _, v := range cleaners {
 		v.Clean()
 	}
-	os.Exit(code)
 }
 
 // Execute executes the root command.
 func Execute() error {
 	cleaners = make([]Cleaner, 0, 2)
-	defer cleanExit(1)
+	defer clean()
 
 	go func() {
 		quit := make(chan os.Signal)
@@ -54,8 +53,8 @@ func Execute() error {
 			select {
 			case sig := <-quit:
 				kill(sig)
-				cleanExit(1)
-				return
+				clean()
+				os.Exit(1)
 			}
 		}
 	}()

--- a/sd-local.go
+++ b/sd-local.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"log"
-
 	"github.com/screwdriver-cd/sd-local/cmd"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Context
The following two bugs were found
- The exit status is set to 1 even if it is a normal exit.
- Some error messages are not displayed at the end of the error.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Separated `os.Exit` from `clean` function.
- Use `logrus` to display errors in sd-local.go.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
