### PR TITLE
fix(2050): Implement create subcommand for config

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	configNew      = config.New
+	newConfigList  = config.NewConfigList
 	apiNew         = screwdriver.New
 	buildLogNew    = buildlog.New
 	launchNew      = launch.New
@@ -153,7 +153,12 @@ func newBuildCmd() *cobra.Command {
 				srcPath = scm.LocalPath()
 			}
 
-			config, err := configNew(filepath.Join(sdlocalDir, "config"))
+			configList, err := newConfigList(filepath.Join(sdlocalDir, "config"))
+			if err != nil {
+				return err
+			}
+
+			config, err := configList.Get(configList.Current)
 			if err != nil {
 				return err
 			}
@@ -188,7 +193,7 @@ func newBuildCmd() *cobra.Command {
 
 			option := launch.Option{
 				Job:           job,
-				Config:        config,
+				Config:        *config,
 				JobName:       jobName,
 				JWT:           api.JWT(),
 				ArtifactsPath: artifactsPath,

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	newConfigList  = config.NewConfigList
+	configNew      = config.New
 	apiNew         = screwdriver.New
 	buildLogNew    = buildlog.New
 	launchNew      = launch.New
@@ -153,17 +153,17 @@ func newBuildCmd() *cobra.Command {
 				srcPath = scm.LocalPath()
 			}
 
-			configList, err := newConfigList(filepath.Join(sdlocalDir, "config"))
+			config, err := configNew(filepath.Join(sdlocalDir, "config"))
 			if err != nil {
 				return err
 			}
 
-			config, err := configList.Get(configList.Current)
+			entry, err := config.Get(config.Current)
 			if err != nil {
 				return err
 			}
 
-			api, err := apiNew(config.APIURL, config.Token)
+			api, err := apiNew(entry.APIURL, entry.Token)
 			if err != nil {
 				return err
 			}
@@ -193,7 +193,7 @@ func newBuildCmd() *cobra.Command {
 
 			option := launch.Option{
 				Job:           job,
-				Config:        *config,
+				Entry:         *entry,
 				JobName:       jobName,
 				JWT:           api.JWT(),
 				ArtifactsPath: artifactsPath,

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -158,7 +158,7 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
-			entry, err := config.Get(config.Current)
+			entry, err := config.Entry(config.Current)
 			if err != nil {
 				return err
 			}

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/screwdriver-cd/sd-local/config"
 	"github.com/screwdriver-cd/sd-local/launch"
 	"github.com/stretchr/testify/assert"
 )
@@ -210,43 +209,6 @@ func TestBuildCmd(t *testing.T) {
 		want := "Error: can't pass the both options `meta` and `meta-file`, please specify only one of them" + buildUsage
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
-	})
-
-	t.Run("Success build cmd with --local", func(t *testing.T) {
-		root := newBuildCmd()
-
-		root.SetArgs([]string{"test", "--local"})
-		buf := bytes.NewBuffer(nil)
-		root.SetOut(buf)
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		cnfDir := filepath.Join(cwd, ".sdlocal")
-		os.MkdirAll(cnfDir, 0777)
-		defer os.RemoveAll(cnfDir)
-
-		cnfPath := filepath.Join(cnfDir, "config")
-		err = os.Link("./testdata/config", cnfPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		defFunc := configNew
-		configNew = func(path string) (config.Config, error) {
-			assert.Equal(t, cnfPath, path)
-			return config.Config{}, nil
-		}
-		defer func() {
-			configNew = defFunc
-		}()
-
-		err = root.Execute()
-		want := ""
-		assert.Equal(t, want, buf.String())
-		assert.Nil(t, err)
 	})
 
 	t.Run("Failed build cmd when too many args", func(t *testing.T) {

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
@@ -14,14 +13,7 @@ const (
 	configDirName  = ".sdlocal"
 )
 
-var filePath = func(isLocalOpt bool) (string, error) {
-	if isLocalOpt {
-		pwd, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(pwd, configDirName, configFileName), nil
-	}
+var filePath = func() (string, error) {
 	home, err := homedir.Dir()
 	if err != nil {
 		return "", err
@@ -48,6 +40,7 @@ func NewConfigCmd() *cobra.Command {
 	configCmd.AddCommand(
 		newConfigSetCmd(),
 		newConfigViewCmd(),
+		newConfigCreateCmd(),
 	)
 
 	return configCmd

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"log"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
@@ -27,11 +26,12 @@ func NewConfigCmd() *cobra.Command {
 		Use:   "config",
 		Short: "Manage settings related to sd-local.",
 		Long:  `Manage settings related to sd-local.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			err := cmd.Help()
 			if err != nil {
-				log.Fatal(err)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	newConfigList = config.NewConfigList
+	configNew = config.New
 )
 
 func newConfigCreateCmd() *cobra.Command {
@@ -25,7 +25,7 @@ The new config has only launcher-version and launcher-image.`,
 				logrus.Fatal(err)
 			}
 
-			configList, err := newConfigList(path)
+			configList, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -30,7 +30,7 @@ The new config has only launcher-version and launcher-image.`,
 				logrus.Fatal(err)
 			}
 
-			err = config.Add(name)
+			err = config.AddEntry(name)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -25,17 +25,17 @@ The new config has only launcher-version and launcher-image.`,
 				logrus.Fatal(err)
 			}
 
-			configList, err := configNew(path)
+			config, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			err = configList.Add(name)
+			err = config.Add(name)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			err = configList.Save()
+			err = config.Save()
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"github.com/screwdriver-cd/sd-local/config"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -17,28 +16,29 @@ func newConfigCreateCmd() *cobra.Command {
 		Long: `Create the config of sd-local.
 The new config has only launcher-version and launcher-image.`,
 		Args: cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 
 			path, err := filePath()
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			config, err := configNew(path)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			err = config.AddEntry(name)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			err = config.Save()
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"github.com/screwdriver-cd/sd-local/config"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	newConfigList = config.NewConfigList
+)
+
+func newConfigCreateCmd() *cobra.Command {
+	configCreateCmd := &cobra.Command{
+		Use:   "create [name]",
+		Short: "Create the config of sd-local",
+		Long: `Create the config of sd-local.
+The new config has only launcher-version and launcher-image.`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+
+			path, err := filePath()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			configList, err := newConfigList(path)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			err = configList.Add(name)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			err = configList.Save()
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+
+	return configCreateCmd
+}

--- a/cmd/config/create_test.go
+++ b/cmd/config/create_test.go
@@ -8,20 +8,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/screwdriver-cd/sd-local/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
-func TestConfigSetCmd(t *testing.T) {
+func TestConfigCreateCmd(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	cnfPath := fmt.Sprintf("%vconfig", rand.Int())
 	defer os.Remove(cnfPath)
 
-	defFilePath := filePath
+	cnew := newConfigList
 	defer func() {
-		filePath = defFilePath
+		newConfigList = cnew
 	}()
-	filePath = func() (string, error) {
-		return cnfPath, nil
+	newConfigList = func(configPath string) (c config.ConfigList, err error) {
+		return config.NewConfigList(cnfPath)
 	}
 
 	testCase := []struct {
@@ -32,19 +34,19 @@ func TestConfigSetCmd(t *testing.T) {
 	}{
 		{
 			name:     "success",
-			args:     []string{"set", "api-url", "example.com"},
+			args:     []string{"create", "test"},
 			wantOut:  "",
 			checkErr: false,
 		},
 		{
 			name:     "failure by too many args",
-			args:     []string{"set", "api-url", "example.com", "many"},
+			args:     []string{"create", "test", "many"},
 			wantOut:  "",
 			checkErr: true,
 		},
 		{
 			name:     "failure by too little args",
-			args:     []string{"set", "api-url"},
+			args:     []string{"create"},
 			wantOut:  "",
 			checkErr: true,
 		},

--- a/cmd/config/create_test.go
+++ b/cmd/config/create_test.go
@@ -63,9 +63,10 @@ func TestConfigCreateCmd(t *testing.T) {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Equal(t, tt.wantOut, buf.String())
+				assert.Contains(t, buf.String(), tt.wantOut)
 			}
 
 		})
 	}
+
 }

--- a/cmd/config/create_test.go
+++ b/cmd/config/create_test.go
@@ -18,12 +18,12 @@ func TestConfigCreateCmd(t *testing.T) {
 	cnfPath := fmt.Sprintf("%vconfig", rand.Int())
 	defer os.Remove(cnfPath)
 
-	cnew := newConfigList
+	cnew := configNew
 	defer func() {
-		newConfigList = cnew
+		configNew = cnew
 	}()
-	newConfigList = func(configPath string) (c config.ConfigList, err error) {
-		return config.NewConfigList(cnfPath)
+	configNew = func(configPath string) (c config.Config, err error) {
+		return config.New(cnfPath)
 	}
 
 	testCase := []struct {

--- a/cmd/config/create_test.go
+++ b/cmd/config/create_test.go
@@ -39,6 +39,12 @@ func TestConfigCreateCmd(t *testing.T) {
 			checkErr: false,
 		},
 		{
+			name:     "failure by Entry that already exists",
+			args:     []string{"create", "default"},
+			wantOut:  "",
+			checkErr: true,
+		},
+		{
 			name:     "failure by too many args",
 			args:     []string{"create", "test", "many"},
 			wantOut:  "",
@@ -63,7 +69,7 @@ func TestConfigCreateCmd(t *testing.T) {
 				assert.NotNil(t, err)
 			} else {
 				assert.Nil(t, err)
-				assert.Contains(t, buf.String(), tt.wantOut)
+				assert.Equal(t, tt.wantOut, buf.String())
 			}
 
 		})

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -3,13 +3,8 @@ package config
 import (
 	"strings"
 
-	"github.com/screwdriver-cd/sd-local/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-)
-
-var (
-	configNew = config.New
 )
 
 func isInvalidKeyError(err error) bool {
@@ -29,19 +24,19 @@ Can set the below settings:
 * Screwdriver.cd launcher image as "launcher-image"`,
 		Args: cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			isLocalOpt, err := cmd.Flags().GetBool("local")
-			if err != nil {
-				logrus.Fatal(err)
-			}
-
 			key, value := args[0], args[1]
 
-			path, err := filePath(isLocalOpt)
+			path, err := filePath()
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			conf, err := configNew(path)
+			configList, err := newConfigList(path)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			conf, err := configList.Get(configList.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -56,6 +51,11 @@ Can set the below settings:
 				} else {
 					logrus.Fatal(err)
 				}
+			}
+
+			err = configList.Save()
+			if err != nil {
+				logrus.Fatal(err)
 			}
 		},
 	}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -35,12 +35,12 @@ Can set the below settings:
 				return err
 			}
 
-			conf, err := config.Entry(config.Current)
+			entry, err := config.Entry(config.Current)
 			if err != nil {
 				return err
 			}
 
-			err = conf.Set(key, value)
+			err = entry.Set(key, value)
 			if err != nil {
 				if isInvalidKeyError(err) {
 					err := cmd.Help()

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -31,7 +31,7 @@ Can set the below settings:
 				logrus.Fatal(err)
 			}
 
-			configList, err := newConfigList(path)
+			configList, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -31,12 +31,12 @@ Can set the below settings:
 				logrus.Fatal(err)
 			}
 
-			configList, err := configNew(path)
+			config, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			conf, err := configList.Get(configList.Current)
+			conf, err := config.Get(config.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}
@@ -53,7 +53,7 @@ Can set the below settings:
 				}
 			}
 
-			err = configList.Save()
+			err = config.Save()
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -3,7 +3,6 @@ package config
 import (
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -23,22 +22,22 @@ Can set the below settings:
 * Screwdriver.cd launcher version as "launcher-version"
 * Screwdriver.cd launcher image as "launcher-image"`,
 		Args: cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			key, value := args[0], args[1]
 
 			path, err := filePath()
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			config, err := configNew(path)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			conf, err := config.Entry(config.Current)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			err = conf.Set(key, value)
@@ -46,17 +45,18 @@ Can set the below settings:
 				if isInvalidKeyError(err) {
 					err := cmd.Help()
 					if err != nil {
-						logrus.Fatal(err)
+						return err
 					}
 				} else {
-					logrus.Fatal(err)
+					return err
 				}
 			}
 
 			err = config.Save()
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
+			return nil
 		},
 	}
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -36,7 +36,7 @@ Can set the below settings:
 				logrus.Fatal(err)
 			}
 
-			conf, err := config.Get(config.Current)
+			conf, err := config.Entry(config.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"text/tabwriter"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -19,20 +18,20 @@ Can see the below settings:
 * Screwdriver.cd Token
 * Screwdriver.cd launcher version
 * Screwdriver.cd launcher image`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			path, err := filePath()
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			config, err := configNew(path)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 
 			c, err := config.Entry(config.Current)
 			if err != nil {
-				logrus.Fatal(err)
+				return err
 			}
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 5, 2, 2, ' ', 0)
 
@@ -44,6 +43,7 @@ Can see the below settings:
 			fmt.Fprintf(w, "launcher-image\t%s\n", c.Launcher.Image)
 
 			w.Flush()
+			return nil
 		},
 	}
 

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -20,15 +20,17 @@ Can see the below settings:
 * Screwdriver.cd launcher version
 * Screwdriver.cd launcher image`,
 		Run: func(cmd *cobra.Command, args []string) {
-			isLocalOpt, err := cmd.Flags().GetBool("local")
+			path, err := filePath()
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			path, err := filePath(isLocalOpt)
+
+			configList, err := newConfigList(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}
-			c, err := configNew(path)
+
+			c, err := configList.Get(configList.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -29,18 +29,18 @@ Can see the below settings:
 				return err
 			}
 
-			c, err := config.Entry(config.Current)
+			entry, err := config.Entry(config.Current)
 			if err != nil {
 				return err
 			}
 			w := tabwriter.NewWriter(cmd.OutOrStdout(), 5, 2, 2, ' ', 0)
 
 			fmt.Fprintln(w, "KEY\tVALUE")
-			fmt.Fprintf(w, "api-url\t%s\n", c.APIURL)
-			fmt.Fprintf(w, "store-url\t%s\n", c.StoreURL)
-			fmt.Fprintf(w, "token\t%s\n", c.Token)
-			fmt.Fprintf(w, "launcher-version\t%s\n", c.Launcher.Version)
-			fmt.Fprintf(w, "launcher-image\t%s\n", c.Launcher.Image)
+			fmt.Fprintf(w, "api-url\t%s\n", entry.APIURL)
+			fmt.Fprintf(w, "store-url\t%s\n", entry.StoreURL)
+			fmt.Fprintf(w, "token\t%s\n", entry.Token)
+			fmt.Fprintf(w, "launcher-version\t%s\n", entry.Launcher.Version)
+			fmt.Fprintf(w, "launcher-image\t%s\n", entry.Launcher.Image)
 
 			w.Flush()
 			return nil

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -30,7 +30,7 @@ Can see the below settings:
 				logrus.Fatal(err)
 			}
 
-			c, err := config.Get(config.Current)
+			c, err := config.Entry(config.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -25,7 +25,7 @@ Can see the below settings:
 				logrus.Fatal(err)
 			}
 
-			configList, err := newConfigList(path)
+			configList, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -25,12 +25,12 @@ Can see the below settings:
 				logrus.Fatal(err)
 			}
 
-			configList, err := configNew(path)
+			config, err := configNew(path)
 			if err != nil {
 				logrus.Fatal(err)
 			}
 
-			c, err := configList.Get(configList.Current)
+			c, err := config.Get(config.Current)
 			if err != nil {
 				logrus.Fatal(err)
 			}

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -13,10 +13,7 @@ func TestViewCmd(t *testing.T) {
 		filePath = fp
 	}()
 
-	filePath = func(isLocal bool) (string, error) {
-		if isLocal {
-			return "./testdata/local_config", nil
-		}
+	filePath = func() (string, error) {
 		return "./testdata/config", nil
 	}
 
@@ -26,24 +23,13 @@ func TestViewCmd(t *testing.T) {
 		expect string
 	}{
 		{
-			name: "success by not use local config",
+			name: "success",
 			args: []string{"view"},
 			expect: `KEY               VALUE
 api-url           api.screwdriver.com
 store-url         store.screwdriver.com
 token             sd-token
 launcher-version  1.0.0
-launcher-image    screwdrivercd/launcher
-`,
-		},
-		{
-			name: "success by use local config",
-			args: []string{"view", "--local"},
-			expect: `KEY               VALUE
-api-url           local.api.screwdriver.com
-store-url         local.store.screwdriver.com
-token             local.sd-token
-launcher-version  stable
 launcher-image    screwdrivercd/launcher
 `,
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,7 +36,19 @@ func (mock mockLaunch) Kill(os.Signal) {}
 func (mock mockLaunch) Clean() {}
 
 func setup() {
-	configNew = func(confPath string) (config.Config, error) { return config.Config{}, nil }
+	newConfigList = func(confPath string) (config.ConfigList, error) {
+		return config.ConfigList{
+			Configs: map[string]*config.Config{
+				"default": {
+					Launcher: config.Launcher{
+						Version: "stable",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
+			},
+			Current: "default",
+		}, nil
+	}
 	apiNew = func(url, token string) (screwdriver.API, error) { return mockAPI{}, nil }
 	buildLogNew = func(filepath string, writer io.Writer) (logger buildlog.Logger, err error) { return mockLogger{}, nil }
 	launchNew = func(option launch.Option) launch.Launcher {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -37,14 +37,16 @@ func (mock mockLaunch) Clean() {}
 
 func setup() {
 	configNew = func(confPath string) (config.Config, error) {
+		defaultEntry := &config.Entry{
+			Launcher: config.Launcher{
+				Version: "stable",
+				Image:   "screwdrivercd/launcher",
+			},
+		}
+
 		return config.Config{
 			Entries: map[string]*config.Entry{
-				"default": {
-					Launcher: config.Launcher{
-						Version: "stable",
-						Image:   "screwdrivercd/launcher",
-					},
-				},
+				"default": defaultEntry,
 			},
 			Current: "default",
 		}, nil

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,9 +36,9 @@ func (mock mockLaunch) Kill(os.Signal) {}
 func (mock mockLaunch) Clean() {}
 
 func setup() {
-	newConfigList = func(confPath string) (config.ConfigList, error) {
-		return config.ConfigList{
-			Configs: map[string]*config.Config{
+	configNew = func(confPath string) (config.Config, error) {
+		return config.Config{
+			Entries: map[string]*config.Entry{
 				"default": {
 					Launcher: config.Launcher{
 						Version: "stable",

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ func newEntry() *Entry {
 	}
 }
 
+// New returns parsed config
 func New(configPath string) (Config, error) {
 	err := create(configPath)
 	if err != nil {
@@ -93,6 +94,7 @@ func New(configPath string) (Config, error) {
 	return c, nil
 }
 
+// Add create new Entry and addd it to Config
 func (c *Config) AddEntry(name string) error {
 	_, exist := c.Entries[name]
 	if exist {
@@ -103,6 +105,7 @@ func (c *Config) AddEntry(name string) error {
 	return nil
 }
 
+// Entry returns an Entry object named `name`
 func (c *Config) Entry(name string) (*Entry, error) {
 	entry, exists := c.Entries[name]
 	if !exists {
@@ -112,6 +115,7 @@ func (c *Config) Entry(name string) (*Entry, error) {
 	return entry, nil
 }
 
+// Save write Config to config file
 func (c *Config) Save() error {
 	file, err := os.OpenFile(c.filePath, os.O_RDWR|os.O_TRUNC, 0666)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -127,24 +127,24 @@ func (c *Config) Save() error {
 }
 
 // Set preserve sd-local config with new value.
-func (c *Entry) Set(key, value string) error {
+func (e *Entry) Set(key, value string) error {
 	switch key {
 	case "api-url":
-		c.APIURL = value
+		e.APIURL = value
 	case "store-url":
-		c.StoreURL = value
+		e.StoreURL = value
 	case "token":
-		c.Token = value
+		e.Token = value
 	case "launcher-version":
 		if value == "" {
 			value = "stable"
 		}
-		c.Launcher.Version = value
+		e.Launcher.Version = value
 	case "launcher-image":
 		if value == "" {
 			value = "screwdrivercd/launcher"
 		}
-		c.Launcher.Image = value
+		e.Launcher.Image = value
 	default:
 		return fmt.Errorf("invalid key %s", key)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -79,6 +79,7 @@ func New(configPath string) (Config, error) {
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to read config file: %v", err)
 	}
+	defer file.Close()
 
 	var c = Config{
 		filePath: configPath,
@@ -92,7 +93,7 @@ func New(configPath string) (Config, error) {
 	return c, nil
 }
 
-func (c *Config) Add(name string) error {
+func (c *Config) AddEntry(name string) error {
 	_, exist := c.Entries[name]
 	if exist {
 		return fmt.Errorf("config `%s` already exists", name)
@@ -102,13 +103,13 @@ func (c *Config) Add(name string) error {
 	return nil
 }
 
-func (c *Config) Get(name string) (*Entry, error) {
-	currentEntry, exists := c.Entries[name]
+func (c *Config) Entry(name string) (*Entry, error) {
+	entry, exists := c.Entries[name]
 	if !exists {
 		return &Entry{}, fmt.Errorf("config `%s` does not exist", name)
 	}
 
-	return currentEntry, nil
+	return entry, nil
 }
 
 func (c *Config) Save() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -386,17 +386,17 @@ func TestSetEntry(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 
-			c := &Entry{}
+			e := &Entry{}
 
 			for key, val := range tt.setting {
-				err := c.Set(key, val)
+				err := e.Set(key, val)
 				if key == "invalidKey" {
 					assert.NotNil(t, err)
 				} else {
 					assert.Nil(t, err)
 				}
 			}
-			assert.Equal(t, tt.expectEntry, *c)
+			assert.Equal(t, tt.expectEntry, *e)
 		})
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -116,7 +116,7 @@ func TestNewConfig(t *testing.T) {
 	})
 }
 
-func TestConfigGet(t *testing.T) {
+func TestConfigEntry(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		config := Config{
 			Entries: map[string]*Entry{
@@ -143,7 +143,7 @@ func TestConfigGet(t *testing.T) {
 			},
 		}
 
-		actual, err := config.Get("default")
+		actual, err := config.Entry("default")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,13 +168,13 @@ func TestConfigGet(t *testing.T) {
 			Current: "doesnotexist",
 		}
 
-		_, err := config.Get(config.Current)
+		_, err := config.Entry(config.Current)
 
 		assert.Equal(t, "config `doesnotexist` does not exist", err.Error())
 	})
 }
 
-func TestConfigAdd(t *testing.T) {
+func TestConfigAddEntry(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		config := Config{
 			Current: "default",
@@ -191,7 +191,7 @@ func TestConfigAdd(t *testing.T) {
 			},
 		}
 
-		err := config.Add("test")
+		err := config.AddEntry("test")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +239,7 @@ func TestConfigAdd(t *testing.T) {
 			},
 		}
 
-		err := config.Add("default")
+		err := config.AddEntry("default")
 		assert.Equal(t, "config `default` already exists", err.Error())
 	})
 }

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -141,29 +141,29 @@ func TestRunBuild(t *testing.T) {
 		id               string
 		expectError      error
 		expectedCommands []string
-		buildConfig      buildConfig
+		buildEntry       buildEntry
 	}{
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
 				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
-			newBuildConfig()},
+			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
 				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
-			newBuildConfig(func(b *buildConfig) {
+			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
-		{"failure build run", "FAIL_BUILD_CONTAINER_RUN", fmt.Errorf("failed to run build container: exit status 1"), []string{}, newBuildConfig()},
-		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL", fmt.Errorf("failed to pull user image exit status 1"), []string{}, newBuildConfig()},
+		{"failure build run", "FAIL_BUILD_CONTAINER_RUN", fmt.Errorf("failed to run build container: exit status 1"), []string{}, newBuildEntry()},
+		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL", fmt.Errorf("failed to pull user image exit status 1"), []string{}, newBuildEntry()},
 	}
 
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeExecCommand(tt.id)
 			execCommand = c.execCmd
-			err := d.runBuild(tt.buildConfig)
+			err := d.runBuild(tt.buildEntry)
 			for i, expectedCommand := range tt.expectedCommands {
 				assert.True(t, strings.Contains(c.commands[i], expectedCommand), "expect %q \nbut got \n%q", expectedCommand, c.commands[i])
 			}
@@ -193,29 +193,29 @@ func TestRunBuildWithSudo(t *testing.T) {
 		id               string
 		expectError      error
 		expectedCommands []string
-		buildConfig      buildConfig
+		buildEntry       buildEntry
 	}{
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
 				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
-			newBuildConfig()},
+			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
 				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd node:12 /opt/sd/local_run.sh ", d.volume)},
-			newBuildConfig(func(b *buildConfig) {
+			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
-		{"failure build run", "FAIL_BUILD_CONTAINER_RUN_SUDO", fmt.Errorf("failed to run build container: exit status 1"), []string{}, newBuildConfig()},
-		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL_SUDO", fmt.Errorf("failed to pull user image exit status 1"), []string{}, newBuildConfig()},
+		{"failure build run", "FAIL_BUILD_CONTAINER_RUN_SUDO", fmt.Errorf("failed to run build container: exit status 1"), []string{}, newBuildEntry()},
+		{"failure build image pull", "FAIL_BUILD_IMAGE_PULL_SUDO", fmt.Errorf("failed to pull user image exit status 1"), []string{}, newBuildEntry()},
 	}
 
 	for _, tt := range testCase {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeExecCommand(tt.id)
 			execCommand = c.execCmd
-			err := d.runBuild(tt.buildConfig)
+			err := d.runBuild(tt.buildEntry)
 			for i, expectedCommand := range tt.expectedCommands {
 				assert.True(t, strings.Contains(c.commands[i], expectedCommand), "expect %q \nbut got \n%q", expectedCommand, c.commands[i])
 			}

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -17,12 +17,12 @@ import (
 
 var testDir string = "./testdata"
 
-func newBuildConfig(options ...func(b *buildConfig)) buildConfig {
+func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 	buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
 	job := screwdriver.Job{}
 	_ = json.Unmarshal(buf, &job)
 
-	b := buildConfig{
+	b := buildEntry{
 		ID: 0,
 		Environment: []EnvVar{{
 			"SD_ARTIFACTS_DIR": "/test/artifacts",
@@ -56,19 +56,19 @@ func TestNew(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 		job.Environment["SD_ARTIFACTS_DIR"] = "/test/artifacts"
 
-		config := config.Config{
+		config := config.Entry{
 			APIURL:   "http://api-test.screwdriver.cd",
 			StoreURL: "http://store-test.screwdriver.cd",
 			Token:    "testtoken",
 			Launcher: config.Launcher{Version: "latest", Image: "screwdrivercd/launcher"},
 		}
 
-		expectedBuildConfig := newBuildConfig()
-		expectedBuildConfig.SrcPath = "/test/sd-local/build/repo"
+		expectedBuildEntry := newBuildEntry()
+		expectedBuildEntry.SrcPath = "/test/sd-local/build/repo"
 
 		option := Option{
 			Job:           job,
-			Config:        config,
+			Entry:         config,
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
@@ -79,7 +79,7 @@ func TestNew(t *testing.T) {
 		launcher := New(option)
 		l, ok := launcher.(*launch)
 		assert.True(t, ok)
-		assert.Equal(t, expectedBuildConfig, l.buildConfig)
+		assert.Equal(t, expectedBuildEntry, l.buildEntry)
 	})
 
 	t.Run("success with default artifacts dir", func(t *testing.T) {
@@ -87,19 +87,19 @@ func TestNew(t *testing.T) {
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
-		config := config.Config{
+		config := config.Entry{
 			APIURL:   "http://api-test.screwdriver.cd",
 			StoreURL: "http://store-test.screwdriver.cd",
 			Token:    "testtoken",
 			Launcher: config.Launcher{Version: "latest", Image: "screwdrivercd/launcher"},
 		}
 
-		expectedBuildConfig := newBuildConfig()
-		expectedBuildConfig.Environment[0]["SD_ARTIFACTS_DIR"] = "/sd/workspace/artifacts"
+		expectedBuildEntry := newBuildEntry()
+		expectedBuildEntry.Environment[0]["SD_ARTIFACTS_DIR"] = "/sd/workspace/artifacts"
 
 		option := Option{
 			Job:           job,
-			Config:        config,
+			Entry:         config,
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
@@ -109,7 +109,7 @@ func TestNew(t *testing.T) {
 		launcher := New(option)
 		l, ok := launcher.(*launch)
 		assert.True(t, ok)
-		assert.Equal(t, expectedBuildConfig, l.buildConfig)
+		assert.Equal(t, expectedBuildEntry, l.buildEntry)
 	})
 }
 
@@ -120,7 +120,7 @@ type mockRunner struct {
 	cleanCalledCount int
 }
 
-func (m *mockRunner) runBuild(buildConfig buildConfig) error {
+func (m *mockRunner) runBuild(buildEntry buildEntry) error {
 	return m.errorRunBuild
 }
 
@@ -143,7 +143,7 @@ func TestRun(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: nil,
 				errorSetupBin: nil,
@@ -169,7 +169,7 @@ func TestRun(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: nil,
 				errorSetupBin: nil,
@@ -195,7 +195,7 @@ func TestRun(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: nil,
 				errorSetupBin: fmt.Errorf("docker: Error response from daemon"),
@@ -221,7 +221,7 @@ func TestRun(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: fmt.Errorf("docker: Error response from daemon"),
 				errorSetupBin: nil,
@@ -249,7 +249,7 @@ func TestKill(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: nil,
 				errorSetupBin: nil,
@@ -268,7 +268,7 @@ func TestClean(t *testing.T) {
 		_ = json.Unmarshal(buf, &job)
 
 		launch := launch{
-			buildConfig: newBuildConfig(),
+			buildEntry: newBuildEntry(),
 			runner: &mockRunner{
 				errorRunBuild: nil,
 				errorSetupBin: nil,


### PR DESCRIPTION
## Context
We are reconsidering sd-local config scheme.
This PR makes sd-local enable to use the new config scheme.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Implement `config create` subcommand to create the new config
- Refactor `config` package and `cmd/config` package
- Remove `--local` option in `cmd/config`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2050
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
