### PR TITLE
fix(2050): Implement delete subcommand for config

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -41,6 +41,7 @@ func NewConfigCmd() *cobra.Command {
 		newConfigSetCmd(),
 		newConfigViewCmd(),
 		newConfigCreateCmd(),
+		newConfigDeleteCmd(),
 	)
 
 	return configCmd

--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newConfigDeleteCmd() *cobra.Command {
+	configDeleteCmd := &cobra.Command{
+		Use:   "delete [name]",
+		Short: "Delete the config of sd-local",
+		Long:  `Delete the config of sd-local.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			path, err := filePath()
+			if err != nil {
+				return err
+			}
+
+			config, err := configNew(path)
+			if err != nil {
+				return err
+			}
+
+			err = config.DeleteEntry(name)
+			if err != nil {
+				return err
+			}
+
+			err = config.Save()
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	return configDeleteCmd
+}

--- a/cmd/config/delete_test.go
+++ b/cmd/config/delete_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/screwdriver-cd/sd-local/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigDeleteCmd(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	cnfPath := fmt.Sprintf("%vconfig", rand.Int())
+	defer os.Remove(cnfPath)
+
+	cnew := configNew
+	defer func() {
+		configNew = cnew
+	}()
+	configNew = func(configPath string) (c config.Config, err error) {
+		return config.New(cnfPath)
+	}
+
+	testCase := []struct {
+		name     string
+		args     []string
+		wantOut  string
+		checkErr bool
+	}{
+		{
+			name:     "success",
+			args:     []string{"delete", "default"},
+			wantOut:  "",
+			checkErr: false,
+		},
+		{
+			name:     "failure by Entry that does not exist",
+			args:     []string{"delete", "test"},
+			wantOut:  "",
+			checkErr: true,
+		},
+		{
+			name:     "failure by too many args",
+			args:     []string{"delete", "test", "many"},
+			wantOut:  "",
+			checkErr: true,
+		},
+		{
+			name:     "failure by too little args",
+			args:     []string{"delete"},
+			wantOut:  "",
+			checkErr: true,
+		},
+	}
+
+	for _, tt := range testCase {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewConfigCmd()
+			cmd.SetArgs(tt.args)
+			buf := bytes.NewBuffer(nil)
+			cmd.SetOut(buf)
+			err := cmd.Execute()
+			if tt.checkErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.wantOut, buf.String())
+			}
+		})
+	}
+}

--- a/cmd/config/delete_test.go
+++ b/cmd/config/delete_test.go
@@ -75,6 +75,12 @@ func TestConfigDeleteCmd(t *testing.T) {
 			wantOut:  "",
 			checkErr: true,
 		},
+		{
+			name:     "failure by trying delete current config",
+			args:     []string{"delete", "default"},
+			wantOut:  "",
+			checkErr: true,
+		},
 	}
 
 	for _, tt := range testCase {

--- a/cmd/config/delete_test.go
+++ b/cmd/config/delete_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"math/rand"
 	"os"
 	"testing"
@@ -26,6 +27,24 @@ func TestConfigDeleteCmd(t *testing.T) {
 		return config.New(cnfPath)
 	}
 
+	f, err := os.Create(cnfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cf, err := os.Open("./testdata/config")
+	_, err = io.Copy(f, cf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cf.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testCase := []struct {
 		name     string
 		args     []string
@@ -34,7 +53,7 @@ func TestConfigDeleteCmd(t *testing.T) {
 	}{
 		{
 			name:     "success",
-			args:     []string{"delete", "default"},
+			args:     []string{"delete", "test"},
 			wantOut:  "",
 			checkErr: false,
 		},

--- a/cmd/config/testdata/config
+++ b/cmd/config/testdata/config
@@ -6,4 +6,11 @@ configs:
     launcher:
       version: 1.0.0
       image: screwdrivercd/launcher
+  test:
+    api-url: api-test.screwdriver.com
+    store-url: store-test.screwdriver.com
+    token: sd-token-test
+    launcher:
+      version: 1.0.0-test
+      image: screwdrivercd/launcher
 current: default

--- a/config/config.go
+++ b/config/config.go
@@ -121,11 +121,13 @@ func (c *Config) Entry(name string) (*Entry, error) {
 
 // DeleteEntry deletes Entry object named `name`
 func (c *Config) DeleteEntry(name string) error {
+	if name == c.Current {
+		return fmt.Errorf("config `%s` is current config", name)
+	}
 	_, exist := c.Entries[name]
 	if !exist {
 		return fmt.Errorf("config `%s` does not exist", name)
 	}
-
 	delete(c.Entries, name)
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -91,10 +91,14 @@ func New(configPath string) (Config, error) {
 		return Config{}, fmt.Errorf("failed to parse config file: %v", err)
 	}
 
+	if c.Entries == nil {
+		c.Entries = make(map[string]*Entry, 0)
+	}
+
 	return c, nil
 }
 
-// Add create new Entry and addd it to Config
+// Add create new Entry and add it to Config
 func (c *Config) AddEntry(name string) error {
 	_, exist := c.Entries[name]
 	if exist {
@@ -113,6 +117,17 @@ func (c *Config) Entry(name string) (*Entry, error) {
 	}
 
 	return entry, nil
+}
+
+// DeleteEntry deletes Entry object named `name`
+func (c *Config) DeleteEntry(name string) error {
+	_, exist := c.Entries[name]
+	if !exist {
+		return fmt.Errorf("config `%s` does not exist", name)
+	}
+
+	delete(c.Entries, name)
+	return nil
 }
 
 // Save write Config to config file

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -331,9 +331,25 @@ func TestConfigDeleteEntry(t *testing.T) {
 		assert.Equal(t, "config `test` does not exist", err.Error())
 	})
 
-	// t.Run("failure by trying to delete current entry", func(t *testing.T{
+	t.Run("failure by trying to delete current entry", func(t *testing.T) {
+		config := Config{
+			Current: "default",
+			Entries: map[string]*Entry{
+				"default": {
+					APIURL:   "api-url",
+					StoreURL: "store-api-url",
+					Token:    "dummy_token",
+					Launcher: Launcher{
+						Version: "latest",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
+			},
+		}
 
-	// }))
+		err := config.DeleteEntry("default")
+		assert.Equal(t, "config `default` is current config", err.Error())
+	})
 }
 
 func TestConfigSave(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -107,24 +107,6 @@ func TestNewConfig(t *testing.T) {
 		assert.Equal(t, testConfig, actual)
 	})
 
-	t.Run("success with empty configs", func(t *testing.T) {
-		cnfPath := filepath.Join(testDir, "emptyConfigs")
-
-		actual, err := New(cnfPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		testConfig := Config{
-			Entries:  map[string]*Entry{},
-			Current:  "default",
-			filePath: cnfPath,
-		}
-
-		assert.Nil(t, err)
-		assert.Equal(t, testConfig, actual)
-	})
-
 	t.Run("failure by invalid yaml", func(t *testing.T) {
 		cnfPath := filepath.Join(testDir, "failureConfig")
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -107,6 +107,24 @@ func TestNewConfig(t *testing.T) {
 		assert.Equal(t, testConfig, actual)
 	})
 
+	t.Run("success with empty configs", func(t *testing.T) {
+		cnfPath := filepath.Join(testDir, "emptyConfigs")
+
+		actual, err := New(cnfPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		testConfig := Config{
+			Entries:  map[string]*Entry{},
+			Current:  "default",
+			filePath: cnfPath,
+		}
+
+		assert.Nil(t, err)
+		assert.Equal(t, testConfig, actual)
+	})
+
 	t.Run("failure by invalid yaml", func(t *testing.T) {
 		cnfPath := filepath.Join(testDir, "failureConfig")
 
@@ -241,6 +259,57 @@ func TestConfigAddEntry(t *testing.T) {
 
 		err := config.AddEntry("default")
 		assert.Equal(t, "config `default` already exists", err.Error())
+	})
+}
+
+func TestConfigDeleteEntry(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		config := Config{
+			Current: "default",
+			Entries: map[string]*Entry{
+				"default": {
+					APIURL:   "api-url",
+					StoreURL: "store-api-url",
+					Token:    "dummy_token",
+					Launcher: Launcher{
+						Version: "latest",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
+			},
+		}
+
+		err := config.DeleteEntry("default")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := Config{
+			Entries: map[string]*Entry{},
+			Current: "default",
+		}
+
+		assert.Equal(t, expected, config)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		config := Config{
+			Current: "default",
+			Entries: map[string]*Entry{
+				"default": {
+					APIURL:   "api-url",
+					StoreURL: "store-api-url",
+					Token:    "dummy_token",
+					Launcher: Launcher{
+						Version: "latest",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
+			},
+		}
+
+		err := config.DeleteEntry("test")
+		assert.Equal(t, "config `test` does not exist", err.Error())
 	})
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -276,17 +276,36 @@ func TestConfigDeleteEntry(t *testing.T) {
 						Image:   "screwdrivercd/launcher",
 					},
 				},
+				"test": {
+					APIURL:   "api-url",
+					StoreURL: "store-api-url",
+					Token:    "dummy_token",
+					Launcher: Launcher{
+						Version: "latest",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
 			},
 		}
 
-		err := config.DeleteEntry("default")
+		err := config.DeleteEntry("test")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		expected := Config{
-			Entries: map[string]*Entry{},
 			Current: "default",
+			Entries: map[string]*Entry{
+				"default": {
+					APIURL:   "api-url",
+					StoreURL: "store-api-url",
+					Token:    "dummy_token",
+					Launcher: Launcher{
+						Version: "latest",
+						Image:   "screwdrivercd/launcher",
+					},
+				},
+			},
 		}
 
 		assert.Equal(t, expected, config)
@@ -311,6 +330,10 @@ func TestConfigDeleteEntry(t *testing.T) {
 		err := config.DeleteEntry("test")
 		assert.Equal(t, "config `test` does not exist", err.Error())
 	})
+
+	// t.Run("failure by trying to delete current entry", func(t *testing.T{
+
+	// }))
 }
 
 func TestConfigSave(t *testing.T) {

--- a/config/testdata/emptyConfigs
+++ b/config/testdata/emptyConfigs
@@ -1,0 +1,2 @@
+configs:
+current: default

--- a/config/testdata/emptyConfigs
+++ b/config/testdata/emptyConfigs
@@ -1,2 +1,0 @@
-configs:
-current: default


### PR DESCRIPTION
## Context
We are reconsidering sd-local config scheme.
This PR makes sd-local enable to use the new config scheme.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Implement `config delete` subcommand to delete a config
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2050
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
