### PR TITLE
fix(2050): fix config view for new config scheme

### DIFF
--- a/cmd/config/testdata/config_no_current
+++ b/cmd/config/testdata/config_no_current
@@ -1,0 +1,16 @@
+configs:
+  default:
+    api-url: api.screwdriver.com
+    store-url: store.screwdriver.com
+    token: sd-token
+    launcher:
+      version: 1.0.0
+      image: screwdrivercd/launcher
+  test:
+    api-url: api-test.screwdriver.com
+    store-url: store-test.screwdriver.com
+    token: sd-token-test
+    launcher:
+      version: 1.0.0-test
+      image: screwdrivercd/launcher
+current: doesnotexist

--- a/cmd/config/testdata/local_config
+++ b/cmd/config/testdata/local_config
@@ -1,9 +1,0 @@
-configs:
-  default:
-    api-url: local.api.screwdriver.com
-    store-url: local.store.screwdriver.com
-    token: local.sd-token
-    launcher:
-      version: stable
-      image: screwdrivercd/launcher
-current: default

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/go-yaml/yaml"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 func newConfigViewCmd() *cobra.Command {

--- a/cmd/config/view.go
+++ b/cmd/config/view.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"fmt"
-	"text/tabwriter"
 
+	"github.com/go-yaml/yaml"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 func newConfigViewCmd() *cobra.Command {
@@ -29,20 +30,26 @@ Can see the below settings:
 				return err
 			}
 
-			entry, err := config.Entry(config.Current)
-			if err != nil {
-				return err
+			for name, entry := range config.Entries {
+				if name == config.Current {
+					fmt.Fprintf(cmd.OutOrStdout(), "* %s:\n", name)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s:\n", name)
+				}
+
+				yaml, err := yaml.Marshal(entry)
+				if err != nil {
+					return err
+				}
+
+				for _, line := range strings.Split(string(yaml), "\n") {
+					if line != "" {
+						fmt.Fprintf(cmd.OutOrStdout(), "    %s\n", line)
+					}
+				}
+
 			}
-			w := tabwriter.NewWriter(cmd.OutOrStdout(), 5, 2, 2, ' ', 0)
 
-			fmt.Fprintln(w, "KEY\tVALUE")
-			fmt.Fprintf(w, "api-url\t%s\n", entry.APIURL)
-			fmt.Fprintf(w, "store-url\t%s\n", entry.StoreURL)
-			fmt.Fprintf(w, "token\t%s\n", entry.Token)
-			fmt.Fprintf(w, "launcher-version\t%s\n", entry.Launcher.Version)
-			fmt.Fprintf(w, "launcher-image\t%s\n", entry.Launcher.Image)
-
-			w.Flush()
 			return nil
 		},
 	}

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -2,8 +2,8 @@ package config
 
 import (
 	"bytes"
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/config/view_test.go
+++ b/cmd/config/view_test.go
@@ -81,6 +81,8 @@ func TestViewCmd(t *testing.T) {
 			}
 			actual := buf.String()
 			for _, expect := range tt.expect {
+				// we do not use assert.Equal but string.Contains.
+				// because maps deserialized by go-yaml has an order different from the written order.
 				assert.True(t, strings.Contains(actual, expect), "expect to contain %q \nbut got \n%q", expect, actual)
 
 			}


### PR DESCRIPTION
## Context
We are now re-considering local config and implementing new config scheme.
This PR makes `sd-local config view` adapts new config scheme as shows in https://github.com/screwdriver-cd/screwdriver/issues/2050#issuecomment-609675304
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- Fix config view appearance
- Delete `cmd/config/testdata/local_config`
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
screwdriver-cd/screwdriver#2050
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
