### PR TITLE
fix(2050): remove local option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Flags:
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
-      --local                  Run command with .sdlocal/config file in current directory.
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.
@@ -55,6 +54,44 @@ Flags:
 ```
 
 ##### config
+_create_
+```bash
+$ sd-local config create --help
+Create the config of sd-local.
+The new config has only launcher-version and launcher-image.
+
+Usage:
+  sd-local config create [name] [flags]
+
+Flags:
+  -h, --help   help for create
+```
+
+_delete_
+```bash
+$ sd-local config delete --help
+Delete the config of sd-local.
+
+Usage:
+  sd-local config delete [name] [flags]
+
+Flags:
+  -h, --help   help for delete
+```
+
+_use_
+```bash
+$ sd-local config use --help
+Use the specified config as current config.
+You can confirm the current config in view sub command.
+
+Usage:
+  sd-local config use [name] [flags]
+
+Flags:
+  -h, --help   help for use
+```
+
 _set_
 ```bash
 $ sd-local config set --help
@@ -71,20 +108,25 @@ Usage:
 
 Flags:
   -h, --help   help for set
-
-Global Flags:
-      --local   Run command with .sdlocal/config file in current directory.
 ```
 
 _view_
 ```bash
 $ sd-local config view
-KEY               VALUE
-api-url           https://api.screwdriver.cd
-store-url         https://store.screwdriver.cd
-token             <API Token>
-launcher-version  latest
-launcher-image    screwdrivercd/launcher
+  anoter:
+    api-url: ""
+    store-url: ""
+    token: ""
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
+* default:
+    api-url: https://api.screwdriver.cd
+    store-url: https://store.screwdriver.cd
+    token: <API Token>
+    launcher:
+      version: stable
+      image: screwdrivercd/launcher
 ```
 
 ##### version

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,16 +25,15 @@ const (
 )
 
 var (
-	configNew      = config.New
-	apiNew         = screwdriver.New
-	buildLogNew    = buildlog.New
-	launchNew      = launch.New
-	artifactsDir   = launch.ArtifactsDir
-	memory         = ""
-	scmNew         = scm.New
-	osMkdirAll     = os.MkdirAll
-	useSudo        = false
-	useLocalConfig = false
+	configNew    = config.New
+	apiNew       = screwdriver.New
+	buildLogNew  = buildlog.New
+	launchNew    = launch.New
+	artifactsDir = launch.ArtifactsDir
+	memory       = ""
+	scmNew       = scm.New
+	osMkdirAll   = os.MkdirAll
+	useSudo      = false
 )
 
 func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
@@ -124,10 +123,6 @@ func newBuildCmd() *cobra.Command {
 			configBaseDir, err := homedir.Dir()
 			if err != nil {
 				return err
-			}
-
-			if useLocalConfig {
-				configBaseDir = cwd
 			}
 
 			sdlocalDir := filepath.Join(configBaseDir, ".sdlocal")
@@ -276,12 +271,6 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"sudo",
 		false,
 		"Use sudo command for container runtime.")
-
-	buildCmd.Flags().BoolVar(
-		&useLocalConfig,
-		"local",
-		false,
-		"Run command with .sdlocal/config file in current directory.")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -20,7 +20,6 @@ Flags:
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
-      --local                  Run command with .sdlocal/config file in current directory.
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -35,8 +35,6 @@ func NewConfigCmd() *cobra.Command {
 		},
 	}
 
-	configCmd.PersistentFlags().Bool("local", false, "Run command with .sdlocal/config file in current directory.")
-
 	configCmd.AddCommand(
 		newConfigSetCmd(),
 		newConfigViewCmd(),

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -94,7 +94,6 @@ Flags:
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build
-      --local                  Run command with .sdlocal/config file in current directory.
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.


### PR DESCRIPTION
## Context
`local` option is no longer needed because we created new config command for multiple configs.

## Objective
This dropped `local` option.

## References
https://github.com/screwdriver-cd/screwdriver/issues/2050

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
