### PR TITLE
fix: add execDockerCommand logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Available Commands:
   version     Display command's version.
 
 Flags:
-  -h, --help   help for sd-local
+  -h, --help      help for sd-local
+  -v, --verbose   verbose output.
 
 Use "sd-local [command] --help" for more information about a command.
 ```
@@ -51,6 +52,9 @@ Flags:
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
       --sudo                   Use sudo command for container runtime.
+
+Global Flags:
+  -v, --verbose   verbose output.
 ```
 
 ##### config
@@ -65,6 +69,9 @@ Usage:
 
 Flags:
   -h, --help   help for create
+
+Global Flags:
+  -v, --verbose   verbose output.
 ```
 
 _delete_
@@ -77,6 +84,9 @@ Usage:
 
 Flags:
   -h, --help   help for delete
+
+Global Flags:
+  -v, --verbose   verbose output.
 ```
 
 _use_
@@ -90,6 +100,9 @@ Usage:
 
 Flags:
   -h, --help   help for use
+
+Global Flags:
+  -v, --verbose   verbose output.
 ```
 
 _set_
@@ -108,6 +121,9 @@ Usage:
 
 Flags:
   -h, --help   help for set
+
+Global Flags:
+  -v, --verbose   verbose output.
 ```
 
 _view_

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -196,6 +196,7 @@ func newBuildCmd() *cobra.Command {
 				OptionEnv:     optionEnv,
 				Meta:          meta,
 				UseSudo:       useSudo,
+				FlagVerbose:   flagVerbose,
 			}
 
 			launch := launchNew(option)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,13 +19,26 @@ type Cleaner interface {
 	Clean()
 }
 
+var (
+	flagVerbose bool
+)
+
 func newRootCmd() *cobra.Command {
+
 	rootCmd := &cobra.Command{
 		Use:   "sd-local",
 		Short: "Run build in local",
 		Long: `Run build instantly on your local machine with
 a mostly the same environment as Screwdriver.cd's`,
 	}
+
+	rootCmd.PersistentFlags().BoolVarP(
+		&flagVerbose,
+		"verbose",
+		"v",
+		false,
+		"verbose output.")
+
 	return rootCmd
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -73,7 +73,7 @@ func TestRootCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Run build instantly on your local machine with\na mostly the same environment as Screwdriver.cd's\n\nUsage:\n  sd-local [command]\n\nAvailable Commands:\n  build       Run screwdriver build.\n  help        Help about any command\n\nFlags:\n  -h, --help   help for sd-local\n\nUse \"sd-local [command] --help\" for more information about a command.\n"
+		want := "Run build instantly on your local machine with\na mostly the same environment as Screwdriver.cd's\n\nUsage:\n  sd-local [command]\n\nAvailable Commands:\n  build       Run screwdriver build.\n  help        Help about any command\n\nFlags:\n  -h, --help      help for sd-local\n  -v, --verbose   verbose output.\n\nUse \"sd-local [command] --help\" for more information about a command.\n"
 		assert.Equal(t, want, buf.String())
 		assert.Nil(t, err)
 	})
@@ -101,6 +101,9 @@ Flags:
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
       --sudo                   Use sudo command for container runtime.
+
+Global Flags:
+  -v, --verbose   verbose output.
 
 `
 		assert.Equal(t, want, buf.String())

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -112,7 +113,10 @@ func (d *docker) execDockerCommand(args ...string) error {
 	if d.useSudo {
 		commands = append([]string{"sudo"}, commands...)
 	}
+	logrus.Infof("$ %s", strings.Join(commands, " "))
 	cmd := execCommand(commands[0], commands[1:]...)
+	cmd.Stdout = logrus.StandardLogger().Writer()
+	cmd.Stderr = logrus.StandardLogger().WriterLevel(logrus.ErrorLevel)
 	d.commands = append(d.commands, cmd)
 	buf := bytes.NewBuffer(nil)
 	cmd.Stderr = buf

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -50,9 +50,10 @@ func TestNewDocker(t *testing.T) {
 			useSudo:           false,
 			commands:          make([]*exec.Cmd, 0, 10),
 			mutex:             &sync.Mutex{},
+			flagVerbose:       false,
 		}
 
-		d := newDocker("launcher", "latest", false)
+		d := newDocker("launcher", "latest", false, false)
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -74,6 +74,7 @@ type Option struct {
 	OptionEnv     EnvVar
 	Meta          Meta
 	UseSudo       bool
+	FlagVerbose   bool
 }
 
 const (
@@ -141,7 +142,7 @@ func createBuildEntry(option Option) buildEntry {
 func New(option Option) Launcher {
 	l := new(launch)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.FlagVerbose)
 	l.buildEntry = createBuildEntry(option)
 
 	return l


### PR DESCRIPTION
## Context
If it takes a long time with `docker pull` etc., it is not display logs for a long time and cannot be understood the progress.
<img width="600" src="https://user-images.githubusercontent.com/24538326/81386010-4720d780-914f-11ea-93a0-18e2f659768c.png">

## Objective
Fix to display the progress of `docker pull` etc with `--verbose` option.
<img width="600" src="https://user-images.githubusercontent.com/24538326/81531105-13d38800-939d-11ea-8b79-1584aca96a02.png">

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
