### PR TITLE
Remove the sleep process in build command

### DIFF
--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -74,7 +74,8 @@ func (l log) Run() {
 		if err != nil {
 			logrus.Errorf("failed to run logger: %v\n", err)
 			logrus.Info("But build is not stopping")
-			l.cancel()
+			close(l.done)
+			break
 		}
 
 		if buildDone && readDone {

--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -25,7 +25,7 @@ type log struct {
 	file   io.Reader
 	writer io.Writer
 	cancel context.CancelFunc
-	done   chan<- interface{}
+	done   chan<- struct{}
 }
 
 type logLine struct {
@@ -36,7 +36,7 @@ type logLine struct {
 }
 
 // New creates new Logger interface.
-func New(filepath string, writer io.Writer, done chan<- interface{}) (Logger, error) {
+func New(filepath string, writer io.Writer, done chan<- struct{}) (Logger, error) {
 	log := log{
 		writer: writer,
 		done:   done,

--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -73,7 +73,7 @@ func (l log) Run() {
 		readDone, err := l.output(reader)
 		if err != nil {
 			logrus.Errorf("failed to run logger: %v\n", err)
-			logrus.Info("But build is not stopping")
+			logrus.Info("But build is still running")
 			close(l.done)
 			break
 		}

--- a/buildlog/buildlog_test.go
+++ b/buildlog/buildlog_test.go
@@ -62,7 +62,7 @@ func TestRun(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
-			done:   make(chan interface{}),
+			done:   make(chan struct{}),
 		}
 
 		go l.Run()
@@ -94,7 +94,7 @@ func TestRun(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
-			done:   make(chan interface{}),
+			done:   make(chan struct{}),
 		}
 
 		go l.Run()
@@ -128,7 +128,7 @@ func TestStop(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
-			done:   make(chan interface{}),
+			done:   make(chan struct{}),
 		}
 
 		go l.Run()
@@ -154,7 +154,7 @@ func TestNew(t *testing.T) {
 
 		writer := bytes.NewBuffer(nil)
 
-		loggerDone := make(chan interface{})
+		loggerDone := make(chan struct{})
 		logger, err := New(tmpFile.Name(), writer, loggerDone)
 		if err != nil {
 			t.Fatal(err)
@@ -177,7 +177,7 @@ func TestNew(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		writer := bytes.NewBuffer(nil)
 
-		loggerDone := make(chan interface{})
+		loggerDone := make(chan struct{})
 		logger, err := New("/", writer, loggerDone)
 		if err == nil {
 			t.Fatal("failure err is nil")

--- a/buildlog/buildlog_test.go
+++ b/buildlog/buildlog_test.go
@@ -62,6 +62,7 @@ func TestRun(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
+			done:   make(chan interface{}),
 		}
 
 		go l.Run()
@@ -93,6 +94,7 @@ func TestRun(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
+			done:   make(chan interface{}),
 		}
 
 		go l.Run()
@@ -126,6 +128,7 @@ func TestStop(t *testing.T) {
 			writer: writer,
 			ctx:    parent,
 			cancel: cancel,
+			done:   make(chan interface{}),
 		}
 
 		go l.Run()
@@ -151,7 +154,8 @@ func TestNew(t *testing.T) {
 
 		writer := bytes.NewBuffer(nil)
 
-		logger, err := New(tmpFile.Name(), writer)
+		loggerDone := make(chan interface{})
+		logger, err := New(tmpFile.Name(), writer, loggerDone)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -173,7 +177,8 @@ func TestNew(t *testing.T) {
 	t.Run("failure", func(t *testing.T) {
 		writer := bytes.NewBuffer(nil)
 
-		logger, err := New("/", writer)
+		loggerDone := make(chan interface{})
+		logger, err := New("/", writer, loggerDone)
 		if err == nil {
 			t.Fatal("failure err is nil")
 		}
@@ -181,6 +186,7 @@ func TestNew(t *testing.T) {
 		expected := log{
 			writer: writer,
 			file:   (*os.File)(nil),
+			done:   loggerDone,
 		}
 
 		msg := err.Error()

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -29,7 +29,7 @@ var (
 	scmNew       = scm.New
 	osMkdirAll   = os.MkdirAll
 	useSudo      = false
-	loggerDone   chan interface{}
+	loggerDone   chan struct{}
 )
 
 func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
@@ -176,7 +176,7 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
-			loggerDone = make(chan interface{})
+			loggerDone = make(chan struct{})
 			logger, err := buildLogNew(filepath.Join(artifactsPath, launch.LogFile), os.Stdout, loggerDone)
 			if err != nil {
 				return err

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,10 +19,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	waitIO = 1
-)
-
 var (
 	configNew    = config.New
 	apiNew       = screwdriver.New
@@ -33,6 +29,7 @@ var (
 	scmNew       = scm.New
 	osMkdirAll   = os.MkdirAll
 	useSudo      = false
+	loggerDone   chan interface{}
 )
 
 func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
@@ -178,7 +175,9 @@ func newBuildCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			logger, err := buildLogNew(filepath.Join(artifactsPath, launch.LogFile), os.Stdout)
+
+			loggerDone = make(chan interface{})
+			logger, err := buildLogNew(filepath.Join(artifactsPath, launch.LogFile), os.Stdout, loggerDone)
 			if err != nil {
 				return err
 			}
@@ -211,7 +210,7 @@ func newBuildCmd() *cobra.Command {
 			}
 
 			logger.Stop()
-			<-logger.Done()
+			<-loggerDone
 
 			return nil
 		},

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/mitchellh/go-homedir"
@@ -211,9 +210,8 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
-			// Wait for I/O processing.
-			time.Sleep(time.Second * waitIO)
 			logger.Stop()
+			<-logger.Done()
 
 			return nil
 		},

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,7 +27,7 @@ func (mock mockAPI) JWT() string { return "" }
 
 func (mock mockLogger) Run() {}
 
-func (mock mockLogger) Stop() {}
+func (mock mockLogger) Stop() { close(loggerDone) }
 
 func (mock mockLaunch) Run() error { return nil }
 
@@ -52,7 +52,9 @@ func setup() {
 		}, nil
 	}
 	apiNew = func(url, token string) (screwdriver.API, error) { return mockAPI{}, nil }
-	buildLogNew = func(filepath string, writer io.Writer) (logger buildlog.Logger, err error) { return mockLogger{}, nil }
+	buildLogNew = func(filepath string, writer io.Writer, done chan<- interface{}) (logger buildlog.Logger, err error) {
+		return mockLogger{}, nil
+	}
 	launchNew = func(option launch.Option) launch.Launcher {
 		return mockLaunch{}
 	}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -52,7 +52,7 @@ func setup() {
 		}, nil
 	}
 	apiNew = func(url, token string) (screwdriver.API, error) { return mockAPI{}, nil }
-	buildLogNew = func(filepath string, writer io.Writer, done chan<- interface{}) (logger buildlog.Logger, err error) {
+	buildLogNew = func(filepath string, writer io.Writer, done chan<- struct{}) (logger buildlog.Logger, err error) {
 		return mockLogger{}, nil
 	}
 	launchNew = func(option launch.Option) launch.Launcher {


### PR DESCRIPTION
## Context
Remove the sleep process in `cmd/build.go`.
Because `logger.Run()` is a sub goroutine, main goroutine must wait until all `builds.log` has been read after the call of `logger.Stop()`.
We make logger have a channel to notify the end of both build and tail process of `builds.log`, so that main goroutine doesn't sleep by waiting for the channel.

## Objective
- Remove `time.Sleep` in `cmd/build.go`
- Add `loggerDone` field to log struct
- `log.output()` returns a bool value indicating whether EOF was read or not


## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
