### PR TITLE
feat: support privileged mode for builds which creates docker container

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,16 +20,17 @@ import (
 )
 
 var (
-	configNew    = config.New
-	apiNew       = screwdriver.New
-	buildLogNew  = buildlog.New
-	launchNew    = launch.New
-	artifactsDir = launch.ArtifactsDir
-	memory       = ""
-	scmNew       = scm.New
-	osMkdirAll   = os.MkdirAll
-	useSudo      = false
-	loggerDone   chan struct{}
+	configNew     = config.New
+	apiNew        = screwdriver.New
+	buildLogNew   = buildlog.New
+	launchNew     = launch.New
+	artifactsDir  = launch.ArtifactsDir
+	memory        = ""
+	scmNew        = scm.New
+	osMkdirAll    = os.MkdirAll
+	useSudo       = false
+	usePrivileged = false
+	loggerDone    chan struct{}
 )
 
 func mergeEnvFromFile(optionEnv *map[string]string, envFilePath string) error {
@@ -194,6 +195,7 @@ func newBuildCmd() *cobra.Command {
 				OptionEnv:     optionEnv,
 				Meta:          meta,
 				UseSudo:       useSudo,
+				UsePrivileged: usePrivileged,
 				FlagVerbose:   flagVerbose,
 			}
 
@@ -269,6 +271,12 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"sudo",
 		false,
 		"Use sudo command for container runtime.")
+
+	buildCmd.Flags().BoolVar(
+		&usePrivileged,
+		"privileged",
+		false,
+		"Use privileged mode for container runtime.")
 
 	return buildCmd
 }

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -103,6 +103,10 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 		dockerCommandOptions = append([]string{fmt.Sprintf("-m%s", buildEntry.MemoryLimit)}, dockerCommandOptions...)
 	}
 
+	if buildEntry.UsePrivileged {
+		dockerCommandOptions = append([]string{"--privileged"}, dockerCommandOptions...)
+	}
+
 	err = d.execDockerCommand(append(dockerCommandArgs, dockerCommandOptions...)...)
 	if err != nil {
 		return fmt.Errorf("failed to run build container: %v", err)

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -60,6 +60,7 @@ type buildEntry struct {
 	MemoryLimit   string             `json:"-"`
 	SrcPath       string             `json:"-"`
 	UseSudo       bool               `json:"-"`
+	UsePrivileged bool               `json:"-"`
 }
 
 // Option is option for launch New
@@ -74,6 +75,7 @@ type Option struct {
 	OptionEnv     EnvVar
 	Meta          Meta
 	UseSudo       bool
+	UsePrivileged bool
 	FlagVerbose   bool
 }
 
@@ -135,6 +137,7 @@ func createBuildEntry(option Option) buildEntry {
 		MemoryLimit:   option.Memory,
 		SrcPath:       option.SrcPath,
 		UseSudo:       option.UseSudo,
+		UsePrivileged: option.UsePrivileged,
 	}
 }
 


### PR DESCRIPTION
## Context

Running builds which builds docker containers is not working properly. 

## Objective

Support privileged mode build containers.

Would need https://github.com/screwdriver-cd/launcher/pull/356/files also to make docker binaries available. 

Without this patch
```
fetch_prerequisites: Mounting cgroup...
fetch_prerequisites: Thu Jun 4 16:32:44 UTC 2020
fetch_prerequisites: Thu Jun 4 16:32:44 UTC 2020
fetch_prerequisites: mount: permission denied (are you root?)
```

With this patch 

```
fetch_prerequisites: Mounting cgroup...
fetch_prerequisites: Thu Jun 4 16:33:19 UTC 2020
fetch_prerequisites: Thu Jun 4 16:33:19 UTC 2020
fetch_prerequisites: cgroup mounted
fetch_prerequisites: starting dockerd...
```

## References



## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
