### PR TITLE
fix: support too long buildlogs

### DIFF
--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -86,8 +86,23 @@ func (l log) Run() {
 	}
 }
 
+func Readln(prefix []byte, r *bufio.Reader) ([]byte, error) {
+	line, isPrefix, err := r.ReadLine()
+
+	if err != nil {
+		return []byte{}, err
+	}
+
+	if isPrefix {
+		return Readln(append(prefix, line...), r)
+	}
+
+	return append(prefix, line...), err
+}
+
 func (l log) output(reader *bufio.Reader) (bool, error) {
-	line, _, err := reader.ReadLine()
+	line, err := Readln([]byte{}, reader)
+
 	if err != nil {
 		if err == io.EOF {
 			return true, nil

--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -86,7 +86,7 @@ func (l log) Run() {
 	}
 }
 
-func Readln(prefix []byte, r *bufio.Reader) ([]byte, error) {
+func readln(prefix []byte, r *bufio.Reader) ([]byte, error) {
 	line, isPrefix, err := r.ReadLine()
 
 	if err != nil {
@@ -94,14 +94,14 @@ func Readln(prefix []byte, r *bufio.Reader) ([]byte, error) {
 	}
 
 	if isPrefix {
-		return Readln(append(prefix, line...), r)
+		return readln(append(prefix, line...), r)
 	}
 
 	return append(prefix, line...), err
 }
 
 func (l log) output(reader *bufio.Reader) (bool, error) {
-	line, err := Readln([]byte{}, reader)
+	line, err := readln([]byte{}, reader)
 
 	if err != nil {
 		if err == io.EOF {


### PR DESCRIPTION
## Context
sd-local caused Error when build logs is too long line (over 4096 bytes).


## Objective
This PR makes sd-local enable to output too long log line.


## License
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
