### PR TITLE
fix: skip parse error

### DIFF
--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -120,7 +120,7 @@ func (l log) output(reader *bufio.Reader) (bool, error) {
 
 	parsedLog, err := parse(line)
 	if err != nil {
-		fmt.Fprintln(l.writer, "\\e[33mwaring: parsed error\\e[m")
+		fmt.Fprintln(l.writer, "\x1b[33mwaring: parsed error\x1b[0m")
 		return false, &parseError{}
 	}
 

--- a/buildlog/buildlog_test.go
+++ b/buildlog/buildlog_test.go
@@ -141,7 +141,7 @@ func TestRun(t *testing.T) {
 		time.Sleep(intervalTime * time.Millisecond)
 		l.Stop()
 
-		expected := "main: test 1\n\\e[33mwaring: parsed error\\e[m\nmain: test 3\n"
+		expected := "main: test 1\n\x1b[33mwaring: parsed error\x1b[0m\nmain: test 3\n"
 		assert.Equal(t, expected, writer.String())
 	})
 }


### PR DESCRIPTION
## Context
sd-local will stop logging when parse error happen.

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We fixed the problem above. If the parse error happens, show warning message and logging will continue.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
![スクリーンショット 2020-07-28 16 47 36](https://user-images.githubusercontent.com/16560466/88635106-3d759300-d0f2-11ea-8cdb-0b91cef14e92.png)

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
