### PR TITLE
fix: sd-local update command

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,11 +16,13 @@ import (
 const githubSlug = "screwdriver-cd/sd-local"
 
 var (
-	currentVersion = version
+	currentVersion string
 	updateFlag     = false
 )
 
 func canUpdate() (*selfupdate.Release, error) {
+	currentVersion = version
+	logrus.Info("Current version:", currentVersion)
 
 	if currentVersion == "dev" {
 		return &selfupdate.Release{}, errors.New("This is a development version and cannot be updated")
@@ -36,7 +38,8 @@ func canUpdate() (*selfupdate.Release, error) {
 	v := semver.MustParse(currentVersion)
 
 	if latest.Version.LTE(v) {
-		return &selfupdate.Release{}, errors.New("Current version is latest")
+		logrus.Warn("Current version is latest")
+		return &selfupdate.Release{}, nil
 	}
 
 	return latest, nil
@@ -55,11 +58,10 @@ func isAborted(input string) (aborted bool, err error) {
 
 func selfUpdate() error {
 	latestVersion, err := canUpdate()
-	if err != nil {
+	if latestVersion.AssetURL == "" {
 		return err
 	}
 
-	logrus.Info("Current version:", currentVersion)
 	if !updateFlag {
 		fmt.Print("Do you want to update to ", latestVersion.Version.String(), "? [y/N]: ")
 		input, err := bufio.NewReader(os.Stdin).ReadString('\n')

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -22,7 +22,7 @@ var (
 
 func canUpdate() (*selfupdate.Release, error) {
 	currentVersion = version
-	logrus.Info("Current version:", currentVersion)
+	logrus.Info("Current version: ", currentVersion)
 
 	if currentVersion == "dev" {
 		return &selfupdate.Release{}, errors.New("This is a development version and cannot be updated")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -31,6 +31,7 @@ func getLatestVersion() (*selfupdate.Release, error) {
 
 	return latest, nil
 }
+
 func canUpdate(latest *selfupdate.Release) (bool, error) {
 	currentVersion := version
 	logrus.Info("Current version: ", currentVersion)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -16,12 +16,11 @@ import (
 const githubSlug = "screwdriver-cd/sd-local"
 
 var (
-	currentVersion string
-	updateFlag     = false
+	updateFlag = false
 )
 
 func canUpdate() (*selfupdate.Release, error) {
-	currentVersion = version
+	currentVersion := version
 	logrus.Info("Current version: ", currentVersion)
 
 	if currentVersion == "dev" {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func setVersion(v string) {
-	currentVersion = v
+	version = v
 }
 
 func TestCheckUserInput(t *testing.T) {
@@ -89,7 +89,9 @@ func TestSelfUpdate(t *testing.T) {
 
 	t.Run("Failed current version is dev", func(t *testing.T) {
 		cmd := newUpdateCmd()
+		backupVersion := version
 		setVersion("dev")
+		defer func() { version = backupVersion }()
 		updateFlag = true
 		buf := bytes.NewBuffer(nil)
 		cmd.SetOut(buf)
@@ -101,18 +103,22 @@ func TestSelfUpdate(t *testing.T) {
 	t.Run("Failed current version is latest", func(t *testing.T) {
 		cmd := newUpdateCmd()
 		latest, _, _ := selfupdate.DetectLatest(githubSlug)
+		backupVersion := version
 		setVersion(latest.Version.String())
+		defer func() { version = backupVersion }()
 		updateFlag = true
 		buf := bytes.NewBuffer(nil)
 		cmd.SetOut(buf)
 		cmd.Execute()
-		want := "Error: Current version is latest\nUsage:\n  update [flags]\n\nFlags:\n  -h, --help   help for update\n  -y, --yes    answer yes for all questions\n\n"
+		want := ""
 		assert.Equal(t, want, buf.String())
 	})
 
 	t.Run("Success selfUpdate command", func(t *testing.T) {
 		cmd := newUpdateCmd()
+		backupVersion := version
 		setVersion("1.0.4")
+		defer func() { version = backupVersion }()
 		updateFlag = true
 		buf := bytes.NewBuffer(nil)
 		cmd.SetOut(buf)

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -13,7 +13,7 @@ func setVersion(v string) {
 	version = v
 }
 
-func TestCheckUserInput(t *testing.T) {
+func TestIsAborted(t *testing.T) {
 
 	cases := []struct {
 		name    string


### PR DESCRIPTION
## Context
FIX: https://github.com/screwdriver-cd/sd-local/pull/42
When I run the update command, show following error.
```
ERROR  [0000] This is a development version and cannot be updated
```
This error is caused by the scope of `currentVersion.`
The problem occurs when building use golang version 1.13.
## Objective

This PR changes the order of processing so that currentVersion is enabled.
The following error message is incorrect.
```
ERROR  [0000] Current version is latest
```
Modify it  a warning message.


## References
related
- https://github.com/screwdriver-cd/sd-local/pull/42
- https://github.com/screwdriver-cd/guide/pull/416
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
