### PR TITLE
Add go mod tidy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ BINARY_NAME=sd-local
 COVERPROFILE?=cover.out
 
 all: test build
-test: format vet lint
+test: format vet lint clean_mod_file
 	$(GOTEST) -race -cover -coverprofile=$(COVERPROFILE) -covermode=atomic ./...
 vet:
 	$(GOCMD) vet -v ./...
@@ -20,6 +20,8 @@ lint:
 	$(GOLINT) $$($(GOLIST_PKG))
 format:
 	find . -name '*.go' | xargs gofmt -s -w
+clean_mod_file:
+	$(GOCMD) mod tidy
 mod_download:
 	$(GOCMD) mod download
 build: mod_download

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -8,6 +8,11 @@ jobs:
         requires: [~pr, ~commit]
         steps:
             - gover: go version
+            - tidy: |
+                go mod tidy
+                echo 'If failure by this step, reason is including not used module in go.mod file.'
+                echo 'Retry to after the using "go mod tidy" command.'
+                git diff --exit-code --quiet HEAD ./go.mod ./go.sum
             - install: go mod download
             - gofmt: (! gofmt -d -s . | grep '^')
             - install-golint: go get golang.org/x/lint/golint

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,8 +10,8 @@ jobs:
             - gover: go version
             - tidy: |
                 go mod tidy
-                echo 'If failure by this step, reason is including not used module in go.mod file.'
-                echo 'Retry to after the using "go mod tidy" command.'
+                echo 'This step failed because there is an unused module in the go.mod file.'
+                echo 'Retry again after using the "go mod tidy" command.'
                 git diff --exit-code --quiet HEAD ./go.mod ./go.sum
             - install: go mod download
             - gofmt: (! gofmt -d -s . | grep '^')


### PR DESCRIPTION
## Context
I often forget to run the `go mod tidy` command.
So I added the `go mod tidy` command to the test job so that I can also run it with the make command.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
- add `go mod tidy` command in test job
- add `go mod tidy` command in Makefile
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
