### PR TITLE
fix: Set exit status by lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test: format vet lint
 vet:
 	$(GOCMD) vet -v ./...
 lint:
-	$(GOLINT) $$($(GOLIST_PKG))
+	$(GOLIST_PKG) | xargs -n 1 $(GOLINT) -set_exit_status
 format:
 	find . -name '*.go' | xargs gofmt -s -w
 mod_download:

--- a/buildlog/buildlog.go
+++ b/buildlog/buildlog.go
@@ -109,9 +109,9 @@ func (l *log) readln(prefix []byte, r *bufio.Reader) ([]byte, error) {
 
 	if isPrefix {
 		return l.readln(append(prefix, line...), r)
-	} else {
-		l.currentLineNum++
 	}
+
+	l.currentLineNum++
 
 	return append(prefix, line...), err
 }


### PR DESCRIPTION
## Context
If lint fails, the build doesn't fail.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
I fixed it so that if the lint fails, the build fails too.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
