### PR TITLE
fix(2238): add limit writing to /dev/pts

### DIFF
--- a/launch/interact.go
+++ b/launch/interact.go
@@ -93,7 +93,7 @@ func (d *Interact) Run(c *exec.Cmd, commands [][]string) error {
 		}
 		// wait Launcher setup
 		time.Sleep(time.Second * 1)
-		_, _ = io.Copy(os.Stdout, strings.NewReader("\r\nWelcome to sd-local interactive mode. If you exit type 'exit'\n"))
+		_, _ = io.Copy(os.Stdout, strings.NewReader("\r\nWelcome to sd-local interactive mode. To exit type 'exit'\n"))
 		_, _ = io.Copy(ptmx, strings.NewReader("\n"))
 		_, _ = io.Copy(ptmx, os.Stdin)
 	}()

--- a/launch/interact.go
+++ b/launch/interact.go
@@ -73,22 +73,18 @@ func (d *Interact) Run(c *exec.Cmd, commands [][]string) error {
 
 			v := append(v, "\n")
 			command := strings.Join(v, " ")
-			if len(command) > maxByte {
-				for {
-					if len(command) <= maxByte {
-						io.Copy(ptmx, strings.NewReader(command[:]))
-						// Wait send the command.
-						time.Sleep(time.Second * 1)
-						break
-					} else {
-						io.Copy(ptmx, strings.NewReader(command[:maxByte]))
-						// Wait send the command.
-						time.Sleep(time.Second * 1)
-						command = command[maxByte:]
-					}
+			for {
+				if len(command) <= maxByte {
+					io.Copy(ptmx, strings.NewReader(command[:]))
+					// Wait send the command.
+					time.Sleep(time.Millisecond * 300)
+					break
+				} else {
+					io.Copy(ptmx, strings.NewReader(command[:maxByte]))
+					// Wait send the command.
+					time.Sleep(time.Millisecond * 300)
+					command = command[maxByte:]
 				}
-			} else {
-				_, _ = io.Copy(ptmx, strings.NewReader(command))
 			}
 		}
 		// wait Launcher setup


### PR DESCRIPTION
## Context
The interactive mode is a new feature in the following PRs
https://github.com/screwdriver-cd/sd-local/pull/45

If the step is large, interactive mode will not work.
https://github.com/screwdriver-cd/screwdriver/issues/2238#issuecomment-724857296

This problem occurs when the size of the command to be sent exceeds the size of `/dev/pts`.

Example.
With ibu1224's mac book pro environment, it's only `1kb`.

Therefore, I will fix it to work properly
## Objective
Determine the maximum number of bytes that can be sent to `/dev/pts`.
If the maximum number you can write to `/dev/pts` is less than this value, need to fix it.

If you have any other good ideas, please let me know.

## References
https://man7.org/linux/man-pages/man4/pts.4.html
https://github.com/screwdriver-cd/screwdriver/issues/2238
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
