### PR TITLE
fix(2274): pass ssh agent to build container

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Flags:
   -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.
+      --privileged             Use privileged mode for container runtime.
+  -S, --socket string          Path to the socket. It will used in build container.
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -59,6 +59,7 @@ func newBuildCmd() *cobra.Command {
 	var envFilePath string
 	var optionMeta string
 	var metaFilePath string
+	var socketPath string
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -200,6 +201,7 @@ func newBuildCmd() *cobra.Command {
 				UseSudo:         useSudo,
 				UsePrivileged:   usePrivileged,
 				InteractiveMode: interactiveMode,
+				SocketPath:      socketPath,
 				FlagVerbose:     flagVerbose,
 			}
 
@@ -288,6 +290,13 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"i",
 		false,
 		"Attach the build container in interactive mode.")
+
+	buildCmd.Flags().StringVarP(
+		&socketPath,
+		"socket",
+		"S",
+		launch.DefaultSocketPath(),
+		"Path to the socket. It will used in build container.")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -25,6 +25,7 @@ Flags:
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.
       --privileged             Use privileged mode for container runtime.
+  -S, --socket string          Path to the socket. It will used in build container.
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -115,6 +115,7 @@ Flags:
       --meta string            Metadata to pass into the build environment, which is represented with JSON format
       --meta-file string       Path to the meta file. meta file is represented with JSON format.
       --privileged             Use privileged mode for container runtime.
+  -S, --socket string          Path to the socket. It will used in build container.
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -122,7 +122,7 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 	}
 
 	dockerCommandArgs := []string{"container", "run"}
-	dockerCommandOptions := []string{"--rm", "-v", srcVol, "-v", artVol, "-v", binVol, "-v", habVol, buildImage}
+	dockerCommandOptions := []string{"--rm", "-v", srcVol, "-v", artVol, "-v", binVol, "-v", habVol, "-v", fmt.Sprintf("%s/.ssh/:/root/.ssh/", os.Getenv("HOME")), "-v", fmt.Sprintf("%s:/tmp/auth.sock", os.Getenv("SSH_AUTH_SOCK")), "-e", "SSH_AUTH_SOCK=/tmp/auth.sock", buildImage}
 	configJSONArg := string(configJSON)
 	if d.interactiveMode {
 		configJSONArg = fmt.Sprintf("%q", configJSONArg)

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -122,7 +122,13 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 	}
 
 	dockerCommandArgs := []string{"container", "run"}
-	dockerCommandOptions := []string{"--rm", "-v", srcVol, "-v", artVol, "-v", binVol, "-v", habVol, "-v", fmt.Sprintf("%s/.ssh/:/root/.ssh/", os.Getenv("HOME")), "-v", fmt.Sprintf("%s:/tmp/auth.sock", os.Getenv("SSH_AUTH_SOCK")), "-e", "SSH_AUTH_SOCK=/tmp/auth.sock", buildImage}
+	sockFile := os.Getenv("SSH_AUTH_SOCK")
+	_, err = os.Stat("/run/host-services/ssh-auth.sock")
+	if err != nil {
+		// for MacOS
+		sockFile = "/run/host-services/ssh-auth.sock"
+	}
+	dockerCommandOptions := []string{"--rm", "-v", srcVol, "-v", artVol, "-v", binVol, "-v", habVol, "-v", fmt.Sprintf("%s:/tmp/auth.sock", sockFile), "-e", "SSH_AUTH_SOCK=/tmp/auth.sock", buildImage}
 	configJSONArg := string(configJSON)
 	if d.interactiveMode {
 		configJSONArg = fmt.Sprintf("%q", configJSONArg)

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -62,9 +62,10 @@ func TestNewDocker(t *testing.T) {
 			mutex:             &sync.Mutex{},
 			flagVerbose:       false,
 			interact:          &Interact{},
+			socketPath:        "/auth.sock",
 		}
 
-		d := newDocker("launcher", "latest", false, false, false)
+		d := newDocker("launcher", "latest", false, false, "/auth.sock", false)
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -158,12 +158,12 @@ func TestRunBuild(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume)},
+				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume)},
+				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -210,12 +210,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume)},
+				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume)},
+				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -264,13 +264,13 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /bin/sh", d.volume, d.habVolume),
+				fmt.Sprintf("sudo docker container run -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK")),
 				"sudo docker attach "},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab node:12 /bin/sh", d.volume, d.habVolume),
+				fmt.Sprintf("sudo docker container run -m2GB -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK")),
 				"sudo docker attach SUCCESS_RUN_BUILD_INTERACT"},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -158,12 +158,12 @@ func TestRunBuild(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
+				fmt.Sprintf("docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
+				fmt.Sprintf("docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -210,12 +210,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
+				fmt.Sprintf("sudo docker container run --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK"))},
+				fmt.Sprintf("sudo docker container run -m2GB --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK"))},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -264,13 +264,13 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK")),
+				fmt.Sprintf("sudo docker container run -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK")),
 				"sudo docker attach "},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s/.ssh/:/root/.ssh/ -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("HOME"), os.Getenv("SSH_AUTH_SOCK")),
+				fmt.Sprintf("sudo docker container run -m2GB -itd --rm -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /bin/sh", d.volume, d.habVolume, os.Getenv("SSH_AUTH_SOCK")),
 				"sudo docker attach SUCCESS_RUN_BUILD_INTERACT"},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"


### PR DESCRIPTION
## Context
fix https://github.com/screwdriver-cd/screwdriver/issues/2274
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Since macOS sockets do not seem to be available on the docker container, ~I decided to mount the ssh key~ instead we can use `/run/host-services/ssh-auth.sock` as the socket. On the linux machine connected with agent forwarding enabled, mounting `$SSH_AUTH_SOCK` solves the problem.

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2274
https://screwdriver-cd.slack.com/archives/C1T5T67PT/p1605035781056600
https://stackoverflow.com/questions/27036936/using-ssh-agent-with-docker-on-macos
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
