### PR TITLE
fix: entry point order

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -78,7 +78,7 @@ func (d *docker) setupBin() error {
 		return fmt.Errorf("failed to pull launcher image: %v", err)
 	}
 
-	_, err = d.execDockerCommand("container", "run", "--rm", "-v", mount, "-v", habMount, image, "--entrypoint", "/bin/echo set up bin")
+	_, err = d.execDockerCommand("container", "run", "--rm", "-v", mount, "-v", habMount, "--entrypoint", "/bin/echo set up bin", image)
 	if err != nil {
 		return fmt.Errorf("failed to prepare build scripts: %v", err)
 	}


### PR DESCRIPTION
## Context

 `sd-local` is failing with error 

```
 INFO   [0002] $ docker container run --rm -v SD_LAUNCH_BIN:/opt/sd/ -v SD_LAUNCH_HAB:/hab  screwdrivercd/launcher:latest --entrypoint /bin/echo set up bin
 INFO   [0003] sudo available in Container?
 root
 Symlink hab cache
 Tue Dec  1 22:39:07 UTC 2020
 Failed to create /hab/pkgs/core/*
 Failed to symlink hab cache
 Creating workspace and log pipe
 Tue Dec  1 22:39:07 UTC 2020
 Waiting for log pipe to be ready
 Tue Dec  1 22:39:07 UTC 2020
 Symlink hab cache, log pipe is ready
 Tue Dec  1 22:39:07 UTC 2020
 find: /opt/sd/hab/pkgs/core: No such file or directory
 find: /opt/sd/hab/pkgs/core: No such file or directory
 /bin/bash: --: invalid option
 Usage:	/bin/bash [GNU long option] [option] ...
	/bin/bash [GNU long option] [option] script-file ...
 GNU long options:
	--debug
	--debugger
	--dump-po-strings
	--dump-strings
	--help
	--init-file
	--login
	--noediting
	--noprofile
	--norc
	--posix
	--pretty-print
	--rcfile
	--restricted
	--verbose
	--version
  Shell options:
	-ilrsD or -c command or -O shopt_option		(invocation only)
	-abefhkmnptuvxBCHP or -o option
 INFO   [0003] $ docker volume rm --force SD_LAUNCH_BIN
```


## Objective

Order of entry point argument matters.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
