### PR TITLE
fix(2280): Envs which include spaces become blank in interactive mode

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -107,7 +107,7 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 		buildEntry.Steps = []screwdriver.Step{
 			{
 				Name:    "sd-local-init",
-				Command: "env > /tmp/sd-local.env",
+				Command: "export > /tmp/sd-local.env",
 			},
 		}
 	}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix https://github.com/screwdriver-cd/screwdriver/issues/2280

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
This PR enables envs which include spaces in sd-local's interactive mode.
```
sd-local# echo $MY_MSG
this is test
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2280

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
