### PR TITLE
Add podman support by omitting the --name arg from volume creation.

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -73,6 +73,7 @@ func newBuildCmd() *cobra.Command {
 	var metaFilePath string
 	var socketPath string
 	var localVolumes []string
+	var dockerIsPodman bool
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -250,6 +251,7 @@ func newBuildCmd() *cobra.Command {
 				SocketPath:      socketPath,
 				FlagVerbose:     flagVerbose,
 				LocalVolumes:    localVolumes,
+				DockerIsPodman:  dockerIsPodman,
 			}
 
 			launch := launchNew(option)
@@ -350,6 +352,16 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"vol",
 		[]string{},
 		"Volumes to mount into build container.")
+
+	defaultDockerIsPodman, err := launch.DockerIsPodman()
+	if err != nil {
+		logrus.Errorf("Error determining whether docker is podman; assuming it is not")
+		defaultDockerIsPodman = false
+	}
+	buildCmd.Flags().BoolVar(&dockerIsPodman,
+		"dockerIsPodman",
+		defaultDockerIsPodman,
+		"Whether docker is podman")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -20,6 +20,7 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+      --dockerIsPodman         Whether docker is podman
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -108,6 +108,7 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+      --dockerIsPodman         Whether docker is podman
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -47,14 +47,14 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
+// DockerIsPodman determines whether docker is podman by asking its version and looking for "podman".
 func DockerIsPodman() (bool, error) {
 	c := exec.Command("docker", "--version")
-	sb := new(strings.Builder)
-	c.Stdout = sb
-	if err := c.Run(); err != nil {
+	data, err := c.Output()
+	if err != nil {
 		return false, fmt.Errorf("cannot determine whether docker is podman: %w", err)
 	}
-	return strings.HasPrefix(sb.String(), "podman"), nil
+	return strings.HasPrefix(string(data), "podman"), nil
 }
 
 func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, dockerIsPodman bool) runner {

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -47,7 +47,7 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
-func dockerIsPodman() (bool, error) {
+func DockerIsPodman() (bool, error) {
 	c := exec.Command("docker", "--version")
 	sb := new(strings.Builder)
 	c.Stdout = sb
@@ -57,11 +57,7 @@ func dockerIsPodman() (bool, error) {
 	return strings.HasPrefix(sb.String(), "podman"), nil
 }
 
-func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string) runner {
-	dockerIsPodman, err := dockerIsPodman()
-	if err != nil {
-		logrus.Panic(err)
-	}
+func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, dockerIsPodman bool) runner {
 	return &docker{
 		volume:            "SD_LAUNCH_BIN",
 		habVolume:         "SD_LAUNCH_HAB",

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -66,7 +66,7 @@ func TestNewDocker(t *testing.T) {
 			localVolumes:      []string{"path:path"},
 		}
 
-		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"})
+		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"}, false)
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -84,6 +84,7 @@ type Option struct {
 	SocketPath      string
 	FlagVerbose     bool
 	LocalVolumes    []string
+	DockerIsPodman  bool
 }
 
 const (
@@ -168,7 +169,7 @@ func createBuildEntry(option Option) buildEntry {
 func New(option Option) Launcher {
 	l := new(launch)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.DockerIsPodman)
 	l.buildEntry = createBuildEntry(option)
 
 	return l


### PR DESCRIPTION
## Context

RHEL8 greatly prefers podman over docker; podman-docker is a shim that has slightly different flags

## Objective

- Determine whether dockerIsPodman by running `docker --version` and looking for "podman".
- Fix the volume creation to not pass the `--name` flag when dockerIsPodman

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
