### PR TITLE
Don't create the volume when dealing with podman.

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -76,27 +76,22 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 }
 
 func (d *docker) setupBin() error {
-	args := []string{"volume", "create"}
 	if !d.dockerIsPodman {
-		args = append(args, "--name")
-	}
-	args = append(args, d.volume)
+		_, err := d.execDockerCommand("volume", "create", "--name", d.volume)
+		if err != nil {
+			return fmt.Errorf("failed to create docker volume: %v", err)
+		}
 
-	_, err := d.execDockerCommand(args...)
-	if err != nil {
-		return fmt.Errorf("failed to create docker volume: %v", err)
-	}
-
-	args[len(args)-1] = d.habVolume
-	_, err = d.execDockerCommand(args...)
-	if err != nil {
-		return fmt.Errorf("failed to create docker hab volume: %v", err)
+		_, err = d.execDockerCommand("volume", "create", "--name", d.habVolume)
+		if err != nil {
+			return fmt.Errorf("failed to create docker hab volume: %v", err)
+		}
 	}
 
 	mount := fmt.Sprintf("%s:/opt/sd/", d.volume)
 	habMount := fmt.Sprintf("%s:/hab", d.habVolume)
 	image := fmt.Sprintf("%s:%s", d.setupImage, d.setupImageVersion)
-	_, err = d.execDockerCommand("pull", image)
+	_, err := d.execDockerCommand("pull", image)
 	if err != nil {
 		return fmt.Errorf("failed to pull launcher image: %v", err)
 	}


### PR DESCRIPTION
## Context

podman only copies VOLUMEs to ones that don't exist when the container is first invoked; remove the code to create volume when dockerIsPodman.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
