### PR TITLE
Both Docker and Podman populate non-existent VOLUMES on first mention; stop pre-creating them

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -73,7 +73,6 @@ func newBuildCmd() *cobra.Command {
 	var metaFilePath string
 	var socketPath string
 	var localVolumes []string
-	var dockerIsPodman bool
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -251,7 +250,6 @@ func newBuildCmd() *cobra.Command {
 				SocketPath:      socketPath,
 				FlagVerbose:     flagVerbose,
 				LocalVolumes:    localVolumes,
-				DockerIsPodman:  dockerIsPodman,
 			}
 
 			launch := launchNew(option)
@@ -352,16 +350,6 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"vol",
 		[]string{},
 		"Volumes to mount into build container.")
-
-	defaultDockerIsPodman, err := launch.DockerIsPodman()
-	if err != nil {
-		logrus.Errorf("Error determining whether docker is podman; assuming it is not")
-		defaultDockerIsPodman = false
-	}
-	buildCmd.Flags().BoolVar(&dockerIsPodman,
-		"dockerIsPodman",
-		defaultDockerIsPodman,
-		"Whether docker is podman")
 
 	return buildCmd
 }

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -20,7 +20,6 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
-      --dockerIsPodman         Whether docker is podman
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -108,7 +108,6 @@ Usage:
 
 Flags:
       --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
-      --dockerIsPodman         Whether docker is podman
   -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
       --env-file string        Path to config file of environment variables. '.env' format file can be used.
   -h, --help                   help for build

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -69,7 +69,7 @@ func (d *docker) setupBin() error {
 	image := fmt.Sprintf("%s:%s", d.setupImage, d.setupImageVersion)
 	_, err := d.execDockerCommand("pull", image)
 	if err != nil {
-		return fmt.Errorf("failed to pull launcher image: %w", err)
+		return fmt.Errorf("failed to pull launcher image: %v", err)
 	}
 
 	// The mechanism for population is that VOLUMEs were declared in the image, so they copy what was in their layer to
@@ -79,7 +79,7 @@ func (d *docker) setupBin() error {
 	//       and then used by subsequent images that then use their content.
 	_, err = d.execDockerCommand("container", "run", "--rm", "-v", mount, "-v", habMount, "--entrypoint", "/bin/echo", image, "set up bin")
 	if err != nil {
-		return fmt.Errorf("failed to prepare build scripts: %w", err)
+		return fmt.Errorf("failed to prepare build scripts: %v", err)
 	}
 
 	return nil

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -64,27 +64,22 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 }
 
 func (d *docker) setupBin() error {
-	_, err := d.execDockerCommand("volume", "create", "--name", d.volume)
-	if err != nil {
-		return fmt.Errorf("failed to create docker volume: %v", err)
-	}
-
-	_, err = d.execDockerCommand("volume", "create", "--name", d.habVolume)
-	if err != nil {
-		return fmt.Errorf("failed to create docker hab volume: %v", err)
-	}
-
 	mount := fmt.Sprintf("%s:/opt/sd/", d.volume)
 	habMount := fmt.Sprintf("%s:/hab", d.habVolume)
 	image := fmt.Sprintf("%s:%s", d.setupImage, d.setupImageVersion)
-	_, err = d.execDockerCommand("pull", image)
+	_, err := d.execDockerCommand("pull", image)
 	if err != nil {
-		return fmt.Errorf("failed to pull launcher image: %v", err)
+		return fmt.Errorf("failed to pull launcher image: %w", err)
 	}
 
+	// The mechanism for population is that VOLUMEs were declared in the image, so they copy what was in their layer to
+	// the mounted location on first mount of non-existing volumes
+	// NOTE: docker allows copying to first-time mounted as well, but both docker and podman copy to non-existing ones.
+	//       therefore, volumes are not pre-created, but created on first mention by the image that populates them
+	//       and then used by subsequent images that then use their content.
 	_, err = d.execDockerCommand("container", "run", "--rm", "-v", mount, "-v", habMount, "--entrypoint", "/bin/echo", image, "set up bin")
 	if err != nil {
-		return fmt.Errorf("failed to prepare build scripts: %v", err)
+		return fmt.Errorf("failed to prepare build scripts: %w", err)
 	}
 
 	return nil
@@ -254,13 +249,14 @@ func (d *docker) kill(sig os.Signal) {
 }
 
 func (d *docker) clean() {
-	_, err := d.execDockerCommand("volume", "rm", "--force", d.volume)
+	// Since the habVolume is mounted inside the mountpoint for volume, it must be removed first.
+	_, err := d.execDockerCommand("volume", "rm", "--force", d.habVolume)
 
 	if err != nil {
 		logrus.Warn(fmt.Errorf("failed to remove volume: %v", err))
 	}
 
-	_, err = d.execDockerCommand("volume", "rm", "--force", d.habVolume)
+	_, err = d.execDockerCommand("volume", "rm", "--force", d.volume)
 
 	if err != nil {
 		logrus.Warn(fmt.Errorf("failed to remove hab volume: %v", err))

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -452,8 +452,8 @@ func TestDockerClean(t *testing.T) {
 		}
 
 		d.clean()
-		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.habVolume), c.commands[0])
-		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.volume), c.commands[1])
+		assert.Equal(t, fmt.Sprintf("sudo docker volume rm --force %v", d.habVolume), c.commands[0])
+		assert.Equal(t, fmt.Sprintf("sudo docker volume rm --force %v", d.volume), c.commands[1])
 	})
 
 	t.Run("failure", func(t *testing.T) {

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -66,7 +66,7 @@ func TestNewDocker(t *testing.T) {
 			localVolumes:      []string{"path:path"},
 		}
 
-		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"}, false)
+		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"})
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -89,7 +89,6 @@ func TestSetupBin(t *testing.T) {
 		expectError error
 	}{
 		{"success", "SUCCESS_SETUP_BIN", nil},
-		{"failure volume create", "FAIL_CREATING_VOLUME", fmt.Errorf("failed to create docker volume: exit status 1")},
 		{"failure container run", "FAIL_CONTAINER_RUN", fmt.Errorf("failed to prepare build scripts: exit status 1")},
 		{"failure launcher image pull", "FAIL_LAUNCHER_PULL", fmt.Errorf("failed to pull launcher image: exit status 1")},
 	}
@@ -123,7 +122,6 @@ func TestSetupBinWithSudo(t *testing.T) {
 		expectError error
 	}{
 		{"success", "SUCCESS_SETUP_BIN_SUDO", nil},
-		{"failure volume create", "FAIL_CREATING_VOLUME_SUDO", fmt.Errorf("failed to create docker volume: exit status 1")},
 		{"failure container run", "FAIL_CONTAINER_RUN_SUDO", fmt.Errorf("failed to prepare build scripts: exit status 1")},
 		{"failure launcher image pull", "FAIL_LAUNCHER_PULL_SUDO", fmt.Errorf("failed to pull launcher image: exit status 1")},
 	}
@@ -425,6 +423,7 @@ func TestDockerClean(t *testing.T) {
 		c := newFakeExecCommand("SUCCESS_TO_CLEAN")
 		execCommand = c.execCmd
 		d := &docker{
+			habVolume:         "SD_LAUNCH_HAB",
 			volume:            "SD_LAUNCH_BIN",
 			setupImage:        "launcher",
 			setupImageVersion: "latest",
@@ -433,7 +432,8 @@ func TestDockerClean(t *testing.T) {
 		}
 
 		d.clean()
-		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.volume), c.commands[0])
+		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.habVolume), c.commands[0])
+		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.volume), c.commands[1])
 	})
 
 	t.Run("success with sudo", func(t *testing.T) {
@@ -443,6 +443,7 @@ func TestDockerClean(t *testing.T) {
 		c := newFakeExecCommand("SUCCESS_TO_CLEAN")
 		execCommand = c.execCmd
 		d := &docker{
+			habVolume:         "SD_LAUNCH_HAB",
 			volume:            "SD_LAUNCH_BIN",
 			setupImage:        "launcher",
 			setupImageVersion: "latest",
@@ -451,7 +452,8 @@ func TestDockerClean(t *testing.T) {
 		}
 
 		d.clean()
-		assert.Equal(t, fmt.Sprintf("sudo docker volume rm --force %v", d.volume), c.commands[0])
+		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.habVolume), c.commands[0])
+		assert.Equal(t, fmt.Sprintf("docker volume rm --force %v", d.volume), c.commands[1])
 	})
 
 	t.Run("failure", func(t *testing.T) {

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -84,7 +84,6 @@ type Option struct {
 	SocketPath      string
 	FlagVerbose     bool
 	LocalVolumes    []string
-	DockerIsPodman  bool
 }
 
 const (
@@ -169,7 +168,7 @@ func createBuildEntry(option Option) buildEntry {
 func New(option Option) Launcher {
 	l := new(launch)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.DockerIsPodman)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes)
 	l.buildEntry = createBuildEntry(option)
 
 	return l


### PR DESCRIPTION
## Context

* Both podman-docker and docker will create volumes that don't exist when first mentioned and honor VOLUME declarations by copying the layer's content to the mounted location for volumes that don't exist.
* Docker also allows noticing "first-mount" of pre-created volumes, but podman doesn't.

So, to find common ground and revert logic created in #59 this PR stops pre-creating the volumes so that it works for both docker and podman-docker

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
