### PR TITLE
fix(2352): sd-local tests won't work in mac

### DIFF
--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -14,7 +15,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const buildUsage = `
+func BuildUsage() string {
+
+	buildUsage := fmt.Sprintf(`
+Usage:
+  build [job name] [flags]
+
+Flags:
+      --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
+      --env-file string        Path to config file of environment variables. '.env' format file can be used.
+  -h, --help                   help for build
+  -i, --interactive            Attach the build container in interactive mode.
+  -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
+      --meta string            Metadata to pass into the build environment, which is represented with JSON format
+      --meta-file string       Path to the meta file. meta file is represented with JSON format.
+      --privileged             Use privileged mode for container runtime.
+  -S, --socket string          Path to the socket. It will used in build container. (default "%s")
+      --src-url string         Specify the source url to build.
+                               ex) git@github.com:<org>/<repo>.git[#<branch>]
+                                   https://github.com/<org>/<repo>.git[#<branch>]
+      --sudo                   Use sudo command for container runtime.
+      --vol strings            Volumes to mount into build container.
+
+`, launch.DefaultSocketPath())
+	if len(launch.DefaultSocketPath()) == 0 {
+		buildUsage = `
 Usage:
   build [job name] [flags]
 
@@ -36,6 +62,10 @@ Flags:
       --vol strings            Volumes to mount into build container.
 
 `
+	}
+
+	return buildUsage
+}
 
 func TestBuildCmd(t *testing.T) {
 	t.Run("Success build cmd", func(t *testing.T) {
@@ -212,7 +242,7 @@ func TestBuildCmd(t *testing.T) {
 		}
 
 		err := root.Execute()
-		want := "Error: can't pass the both options `meta` and `meta-file`, please specify only one of them" + buildUsage
+		want := "Error: can't pass the both options `meta` and `meta-file`, please specify only one of them" + BuildUsage()
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})
@@ -223,7 +253,7 @@ func TestBuildCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Error: accepts 1 arg(s), received 2" + buildUsage
+		want := "Error: accepts 1 arg(s), received 2" + BuildUsage()
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})
@@ -235,7 +265,7 @@ func TestBuildCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := "Error: accepts 1 arg(s), received 0" + buildUsage
+		want := "Error: accepts 1 arg(s), received 0" + BuildUsage()
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -102,7 +103,33 @@ func TestRootCmd(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		root.SetOut(buf)
 		err := root.Execute()
-		want := `Error: accepts 1 arg(s), received 0
+		want := `Error: accepts 1 arg(s), received 0` + fmt.Sprintf(`
+Usage:
+  sd-local build [job name] [flags]
+
+Flags:
+      --artifacts-dir string   Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR. (default "sd-artifacts")
+  -e, --env stringToString     Set key and value relationship which is set as environment variables of Build Container. (<key>=<value>) (default [])
+      --env-file string        Path to config file of environment variables. '.env' format file can be used.
+  -h, --help                   help for build
+  -i, --interactive            Attach the build container in interactive mode.
+  -m, --memory string          Memory limit for build container, which take a positive integer, followed by a suffix of b, k, m, g.
+      --meta string            Metadata to pass into the build environment, which is represented with JSON format
+      --meta-file string       Path to the meta file. meta file is represented with JSON format.
+      --privileged             Use privileged mode for container runtime.
+  -S, --socket string          Path to the socket. It will used in build container. (default "%s")
+      --src-url string         Specify the source url to build.
+                               ex) git@github.com:<org>/<repo>.git[#<branch>]
+                                   https://github.com/<org>/<repo>.git[#<branch>]
+      --sudo                   Use sudo command for container runtime.
+      --vol strings            Volumes to mount into build container.
+
+Global Flags:
+  -v, --verbose   verbose output.
+
+`, launch.DefaultSocketPath())
+		if len(launch.DefaultSocketPath()) == 0 {
+			want = `Error: accepts 1 arg(s), received 0
 Usage:
   sd-local build [job name] [flags]
 
@@ -127,6 +154,7 @@ Global Flags:
   -v, --verbose   verbose output.
 
 `
+		}
 		assert.Equal(t, want, buf.String())
 		assert.NotNil(t, err)
 	})

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -148,6 +148,7 @@ func TestRunBuild(t *testing.T) {
 		volume:            "SD_LAUNCH_BIN",
 		setupImage:        "launcher",
 		setupImageVersion: "latest",
+		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 	}
 
 	testCase := []struct {
@@ -200,6 +201,7 @@ func TestRunBuildWithSudo(t *testing.T) {
 		setupImage:        "launcher",
 		setupImageVersion: "latest",
 		useSudo:           true,
+		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 	}
 
 	testCase := []struct {
@@ -254,6 +256,7 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		useSudo:           true,
 		interactiveMode:   true,
 		interact:          &mockInteract{},
+		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 	}
 
 	testCase := []struct {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Fix the following issue
https://github.com/screwdriver-cd/screwdriver/issues/2352

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
`SSH_AUTH_SOCK` is dependent on the environment in which it is run.
So, get the `SSH_AUTH_SOCK` of the execution environment and run the test.
Also, add the case when `SSH_AUTH_SOCK` is not set and it works
## Reference
issue: https://github.com/screwdriver-cd/screwdriver/issues/2352

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
