### PR TITLE
Fix an error handling for `config set` command

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -46,13 +46,9 @@ Can set the below settings:
 			err = entry.Set(key, value)
 			if err != nil {
 				if isInvalidKeyError(err) {
-					err := cmd.Help()
-					if err != nil {
-						return err
-					}
-				} else {
-					return err
+					cmd.Help()
 				}
+				return err
 			}
 
 			err = config.Save()

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -46,7 +46,7 @@ Can set the below settings:
 			err = entry.Set(key, value)
 			if err != nil {
 				if isInvalidKeyError(err) {
-					cmd.Help()
+					_ = cmd.Help()
 				}
 				return err
 			}

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -27,26 +27,22 @@ func TestConfigSetCmd(t *testing.T) {
 	testCase := []struct {
 		name     string
 		args     []string
-		wantOut  string
-		checkErr bool
+		existErr bool
 	}{
 		{
 			name:     "success",
 			args:     []string{"set", "api-url", "example.com"},
-			wantOut:  "",
-			checkErr: false,
+			existErr: false,
 		},
 		{
 			name:     "failure by too many args",
 			args:     []string{"set", "api-url", "example.com", "many"},
-			wantOut:  "",
-			checkErr: true,
+			existErr: true,
 		},
 		{
 			name:     "failure by too little args",
 			args:     []string{"set", "api-url"},
-			wantOut:  "",
-			checkErr: true,
+			existErr: true,
 		},
 	}
 
@@ -57,13 +53,7 @@ func TestConfigSetCmd(t *testing.T) {
 			buf := bytes.NewBuffer(nil)
 			cmd.SetOut(buf)
 			err := cmd.Execute()
-			if tt.checkErr {
-				assert.NotNil(t, err)
-			} else {
-				assert.Nil(t, err)
-				assert.Equal(t, tt.wantOut, buf.String())
-			}
-
+			assert.Equal(t, tt.existErr, err != nil)
 		})
 	}
 }

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -44,6 +44,11 @@ func TestConfigSetCmd(t *testing.T) {
 			args:     []string{"set", "api-url"},
 			existErr: true,
 		},
+		{
+			name:     "filure by setting an invalid key",
+			args:     []string{"set", "invalid-key", "invalid-value"},
+			existErr: true,
+		},
 	}
 
 	for _, tt := range testCase {

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -45,7 +45,7 @@ func TestConfigSetCmd(t *testing.T) {
 			existErr: true,
 		},
 		{
-			name:     "filure by setting an invalid key",
+			name:     "failure by setting an invalid key",
 			args:     []string{"set", "invalid-key", "invalid-value"},
 			existErr: true,
 		},


### PR DESCRIPTION
## Context

If the wrong key is set, the exit code will be zero.

```
$ sd-local config set invalid-key invalid-value
Set the config of sd-local.
Can set the below settings:
* Screwdriver.cd API URL as "api-url"
* Screwdriver.cd Store URL as "store-url"
* Screwdriver.cd Token as "token"
* Screwdriver.cd launcher version as "launcher-version"
* Screwdriver.cd UUID as "UUID"
* Screwdriver.cd launcher image as "launcher-image"

Usage:
  sd-local config set [key] [value] [flags]

Flags:
  -h, --help   help for set

Global Flags:

$ echo $?
0
```

Since it is an error, a non-zero value should be returned.

## Objective

* Refactoring test code (https://github.com/screwdriver-cd/sd-local/commit/826704e1aba3b1d1b0c1abee8562aabb26018b52)
* Add a test case (https://github.com/screwdriver-cd/sd-local/pull/70/commits/a567a60eca0b0df8576cc0c5ceceba91a54e65cf)
  * This should be passed.
* Fix error handling (https://github.com/screwdriver-cd/sd-local/pull/70/commits/2a8bb75f8e0c2302db95323f95df463d65b780d9)

```
 go run ./sd-local.go config set invalid-key invalid-value
Set the config of sd-local.
Can set the below settings:
* Screwdriver.cd API URL as "api-url"
* Screwdriver.cd Store URL as "store-url"
* Screwdriver.cd Token as "token"
* Screwdriver.cd launcher version as "launcher-version"
* Screwdriver.cd UUID as "uuid"
* Screwdriver.cd launcher image as "launcher-image"

Usage:
  sd-local config set [key] [value] [flags]

Flags:
  -h, --help   help for set

Global Flags:
  -v, --verbose   verbose output.
ERROR  [0000] invalid key invalid-key
exit status 1
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
