### PR TITLE
fix: hide logs in interactive mode

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -57,7 +57,7 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 		commands:          make([]*exec.Cmd, 0, 10),
 		mutex:             &sync.Mutex{},
 		flagVerbose:       flagVerbose,
-		interact:          &Interact{},
+		interact:          &Interact{flagVerbose: flagVerbose},
 		socketPath:        socketPath,
 		localVolumes:      localVolumes,
 	}

--- a/launch/interact.go
+++ b/launch/interact.go
@@ -71,14 +71,18 @@ func (d *Interact) Run(c *exec.Cmd, commands [][]string) error {
 	// Copy stdin to the pty and the pty to stdout.
 	go func() {
 		if !d.flagVerbose {
+			// Clear entire screen
 			_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[2J"))
 		}
 
 		for _, v := range commands {
 			func() {
 				if !d.flagVerbose {
+					// Moves the cursor to row 1, column 1, and Clear from cursor to end of screen.
 					_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[1;H\x1b[0Jplease wait while sd-local setup process...\r\n"))
+					// Decreased intensity
 					_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[2m"))
+					// Normal intensity
 					defer io.Copy(os.Stdout, strings.NewReader("\x1b[22m"))
 				}
 
@@ -102,8 +106,10 @@ func (d *Interact) Run(c *exec.Cmd, commands [][]string) error {
 		// wait Launcher setup
 		time.Sleep(time.Second * 1)
 		if !d.flagVerbose {
+			// Moves the cursor to row 1, column 1, and Clear from cursor to end of screen.
 			_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[1;H\x1b[0J"))
 		} else {
+			// spacer
 			_, _ = io.Copy(os.Stdout, strings.NewReader("\r\n"))
 		}
 		_, _ = io.Copy(os.Stdout, strings.NewReader("Welcome to sd-local interactive mode. To exit type 'exit'\n"))

--- a/launch/interact.go
+++ b/launch/interact.go
@@ -22,6 +22,7 @@ type Interacter interface {
 
 // Interact takes interactive processing
 type Interact struct {
+	flagVerbose bool
 }
 
 // Run runs interactive process
@@ -69,27 +70,43 @@ func (d *Interact) Run(c *exec.Cmd, commands [][]string) error {
 
 	// Copy stdin to the pty and the pty to stdout.
 	go func() {
-		for _, v := range commands {
+		if !d.flagVerbose {
+			_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[2J"))
+		}
 
-			v := append(v, "\n")
-			command := strings.Join(v, " ")
-			for {
-				if len(command) <= maxByte {
-					io.Copy(ptmx, strings.NewReader(command[:]))
-					// Wait send the command.
-					time.Sleep(time.Millisecond * 300)
-					break
-				} else {
-					io.Copy(ptmx, strings.NewReader(command[:maxByte]))
-					// Wait send the command.
-					time.Sleep(time.Millisecond * 300)
-					command = command[maxByte:]
+		for _, v := range commands {
+			func() {
+				if !d.flagVerbose {
+					_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[1;H\x1b[0Jplease wait while sd-local setup process...\r\n"))
+					_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[2m"))
+					defer io.Copy(os.Stdout, strings.NewReader("\x1b[22m"))
 				}
-			}
+
+				v := append(v, "\n")
+				command := strings.Join(v, " ")
+				for {
+					if len(command) <= maxByte {
+						io.Copy(ptmx, strings.NewReader(command[:]))
+						// Wait send the command.
+						time.Sleep(time.Millisecond * 300)
+						break
+					} else {
+						io.Copy(ptmx, strings.NewReader(command[:maxByte]))
+						// Wait send the command.
+						time.Sleep(time.Millisecond * 300)
+						command = command[maxByte:]
+					}
+				}
+			}()
 		}
 		// wait Launcher setup
 		time.Sleep(time.Second * 1)
-		_, _ = io.Copy(os.Stdout, strings.NewReader("\r\nWelcome to sd-local interactive mode. To exit type 'exit'\n"))
+		if !d.flagVerbose {
+			_, _ = io.Copy(os.Stdout, strings.NewReader("\x1b[1;H\x1b[0J"))
+		} else {
+			_, _ = io.Copy(os.Stdout, strings.NewReader("\r\n"))
+		}
+		_, _ = io.Copy(os.Stdout, strings.NewReader("Welcome to sd-local interactive mode. To exit type 'exit'\n"))
 		_, _ = io.Copy(ptmx, strings.NewReader("\n"))
 		_, _ = io.Copy(ptmx, os.Stdin)
 	}()


### PR DESCRIPTION
## Context
The interactive mode of sd-local has a lot of logs of the setup process, which is unnecessary for the user, and it is difficult to know that the startup is completed.
<img width="1000" src="https://user-images.githubusercontent.com/24538326/113664363-95838100-96e6-11eb-8830-46f7d63ea490.png">

## Objective
The log of the setup process will hidden.
<img width="1000" src="https://user-images.githubusercontent.com/24538326/113664081-18580c00-96e6-11eb-922d-e92e73cf868a.gif">

If the verbose option is set true, the behavior remains the same.

## References
https://en.wikipedia.org/wiki/ANSI_escape_code

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
