### PR TITLE
docs: add evalation order of env to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Flags:
 Global Flags:
   -v, --verbose   verbose output.
 ```
+* There are some ways to set environment variables for a build. If the same key is set in more than one way, the priority is as follows:
+  1. `--env` or `-e` Flag
+  1. `--env-file` Flag
+  1. environment of screwdriver.yaml
+  1. defaultValue (e.g.: `SD_TOKEN`, `SD_API_URL`)
 
 ##### config
 _create_

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Global Flags:
   1. `--env` or `-e` Flag
   1. `--env-file` Flag
   1. environment in a screwdriver.yaml
-  1. default value (e.g.: `SD_TOKEN`, `SD_API_URL`)
+  1. defaultEnv (e.g.: `SD_TOKEN`, `SD_API_URL`)
 
 ##### config
 _create_

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ Global Flags:
 * There are some ways to set environment variables for a build. If the same key is set in more than one way, the priority is as follows:
   1. `--env` or `-e` Flag
   1. `--env-file` Flag
-  1. environment of screwdriver.yaml
-  1. defaultValue (e.g.: `SD_TOKEN`, `SD_API_URL`)
+  1. environment in a screwdriver.yaml
+  1. default value (e.g.: `SD_TOKEN`, `SD_API_URL`)
 
 ##### config
 _create_


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For requests of https://github.com/screwdriver-cd/sd-local/pull/74#issuecomment-951476434.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

I added evalation order of environment variable for a build to README.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/sd-local/pull/74

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
