### PR TITLE
fix: Enables double quotes in env

### DIFF
--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-var regexpForUnmarshal = regexp.MustCompile(`"(.*?)" *: *"(.*?)"`)
+var regexpForUnmarshal = regexp.MustCompile(`"(.*?)" *: *"((.*?(\\\")?)+)"`)
 
 const (
 	apiVersion        = "v4"

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -79,6 +79,10 @@ func TestJob(t *testing.T) {
 					"TEST_ENV",
 					"hoge",
 				},
+				{
+					"ESCAPED_COMMAND",
+					"-c \\\"echo FOO\\\"",
+				},
 			},
 			Image: "alpine",
 		}

--- a/screwdriver/testdata/validatedSuccess.json
+++ b/screwdriver/testdata/validatedSuccess.json
@@ -13,7 +13,8 @@
           }
         ],
         "environment": {
-          "TEST_ENV": "hoge"
+          "TEST_ENV": "hoge",
+          "ESCAPED_COMMAND": "-c \"echo FOO\""
         },
         "image": "alpine"
       }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
sd-local fails because it cannot successfully decode screwdriver.yaml if the environment value contains `" `.

Here is an example of screwdriver.yaml that fails:
```yaml
jobs:
  test:
    image: ubuntu:latest
    steps:
      - get: |
          echo "$PATH"
          echo "$FOO"
    environment:
      PATH: $PATH:/whatever
      FOO: a"b"c
```

The error message is as follows.
```sh
ERROR  [0001] failed to run build: json: error calling MarshalJSON for type screwdriver.EnvVar: unexpected end of JSON input
```


It is not uncommon for double quotes to be used for the value of the environment, and we also operate it as part of an execution command such as:
```yaml
FOO: -c "echo FOO"
```

This is an issue that needs to be fixed.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Make `"` available for the value of the environment. This PR allows you to operate without error as follows.
```yaml
get: echo "$FOO"
get:
get:
get: -c "echo FOO"
get:
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/sd-local/pull/74

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
