### PR TITLE
feat: support passing custom build user

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Flags:
       --sudo                   Use sudo command for container runtime.
       --vol string             Mount local volumes into build container. (<src>:<destination>) (default [])
 
+  -u, --user string            Change default build user. Default value is from container in use.
 Global Flags:
   -v, --verbose   verbose output.
 ```

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -77,6 +77,7 @@ func newBuildCmd() *cobra.Command {
 	var metaFilePath string
 	var socketPath string
 	var localVolumes []string
+	var buildUser string
 
 	buildCmd := &cobra.Command{
 		Use:   "build [job name]",
@@ -256,6 +257,7 @@ func newBuildCmd() *cobra.Command {
 				SocketPath:      socketPath,
 				FlagVerbose:     flagVerbose,
 				LocalVolumes:    localVolumes,
+				BuildUser:       buildUser,
 			}
 
 			launch := launchNew(option)
@@ -356,6 +358,13 @@ ex) git@github.com:<org>/<repo>.git[#<branch>]
 		"vol",
 		[]string{},
 		"Volumes to mount into build container.")
+
+	buildCmd.Flags().StringVarP(
+		&buildUser,
+		"user",
+		"u",
+		"",
+		"Change default build user. Default value is from container in use.")
 
 	return buildCmd
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,6 +60,7 @@ Flags:
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
       --sudo                   Use sudo command for container runtime.
+  -u, --user string            Change default build user. Default value is from container in use.
       --vol strings            Volumes to mount into build container.
 
 `, defaultSocketPath)

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -31,6 +31,7 @@ type docker struct {
 	interact          Interacter
 	socketPath        string
 	localVolumes      []string
+	buildUser         string
 }
 
 var _ runner = (*docker)(nil)
@@ -46,7 +47,7 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
-func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string) runner {
+func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, buildUser string) runner {
 	return &docker{
 		volume:            "SD_LAUNCH_BIN",
 		habVolume:         "SD_LAUNCH_HAB",
@@ -60,6 +61,7 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 		interact:          &Interact{flagVerbose: flagVerbose},
 		socketPath:        socketPath,
 		localVolumes:      localVolumes,
+		buildUser:         buildUser,
 	}
 }
 
@@ -146,6 +148,10 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 
 	if buildEntry.UsePrivileged {
 		dockerCommandOptions = append([]string{"--privileged"}, dockerCommandOptions...)
+	}
+
+	if d.buildUser != "" {
+		dockerCommandOptions = append([]string{fmt.Sprintf("-u%s", d.buildUser)}, dockerCommandOptions...)
 	}
 
 	if d.interactiveMode {

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -66,9 +66,10 @@ func TestNewDocker(t *testing.T) {
 			interact:          &Interact{},
 			socketPath:        "/auth.sock",
 			localVolumes:      []string{"path:path"},
+			buildUser:         "jithin",
 		}
 
-		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"})
+		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"}, "jithin")
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -81,6 +81,7 @@ type Option struct {
 	SocketPath      string
 	FlagVerbose     bool
 	LocalVolumes    []string
+	BuildUser       string
 }
 
 const (
@@ -170,7 +171,7 @@ func createBuildEntry(option Option) buildEntry {
 func New(option Option) Launcher {
 	l := new(launch)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser)
 	l.buildEntry = createBuildEntry(option)
 
 	return l


### PR DESCRIPTION
## Context

https://github.com/screwdriver-cd/screwdriver/issues/2645

## Objective

Support `-u` flag to pass a custom container user.


```

❯ ./sd-local build test -i
INFO   [0000] Prepare to start build...
INFO   [0028] Pulling docker image from golang:1.17.2...
please wait while sd-local setup process...
...
Welcome to sd-local interactive mode. To exit type 'exit'

sd-local# whoami
root
```

```
❯ ./sd-local build test -i -u nobody
INFO   [0001] Prepare to start build...
INFO   [0009] Pulling docker image from golang:1.17.2...
please wait while sd-local setup process...
.......
sd-local#whoami
nobody
sd-local#
```
## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
