### PR TITLE
feat(2692): add arm64 and universal binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -13,3 +14,6 @@ builds:
 archives:
   - format: binary
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
+universal_binaries:
+- replace: false


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
`sd-local` would be used on macOS. And latest Mac computers an ARM-based.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
- add binary for arm64 arch
- add universal binary for macOS with amd64 and arm64

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
- [macOS Universal Binaries - GoReleaser](https://goreleaser.com/customization/universalbinaries/)
- https://github.com/screwdriver-cd/screwdriver/issues/2692

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
