### PR TITLE
fix: use latest patch version of golang 1.17

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: golang:1.17.2
+    image: golang:1.17
     environment:
         GOPATH: /sd/workspace
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

go version is pinned.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

use latest patch version of golang 1.17.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
