### PR TITLE
feat(2969): Make docker commands available in the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Global Flags:
   1. environment in a screwdriver.yaml
   1. defaultEnv (e.g.: `SD_TOKEN`, `SD_API_URL`)
 
+* You can use docker commands in the build to run containers, build images, etc.
+  * Set `screwdriver.cd/dockerEnabled: true` in the job annotations.
+```yaml
+jobs:
+  main:
+    annotations:
+      screwdriver.cd/dockerEnabled: true
+```
+
 ##### config
 _create_
 ```bash

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -18,6 +18,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type DinD struct {
+	volume          string
+	shareVolumeName string
+	shareVolumePath string
+	container       string
+	network         string
+	image           string
+}
+
 type docker struct {
 	volume            string
 	habVolume         string
@@ -32,6 +41,7 @@ type docker struct {
 	socketPath        string
 	localVolumes      []string
 	buildUser         string
+	dind              DinD
 }
 
 var _ runner = (*docker)(nil)
@@ -62,6 +72,14 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 		socketPath:        socketPath,
 		localVolumes:      localVolumes,
 		buildUser:         buildUser,
+		dind: DinD{
+			volume:          "SD_DIND_CERT",
+			shareVolumeName: "SD_DIND_SHARE",
+			shareVolumePath: "/opt/sd_dind_share",
+			container:       "sd-local-dind",
+			network:         "sd-local-dind-bridge",
+			image:           "docker:23.0.1-dind-rootless",
+		},
 	}
 }
 
@@ -88,6 +106,14 @@ func (d *docker) setupBin() error {
 }
 
 func (d *docker) runBuild(buildEntry buildEntry) error {
+	dockerEnabled, _ := buildEntry.Annotations["screwdriver.cd/dockerEnabled"].(bool)
+
+	if dockerEnabled {
+		if err := d.runDinD(); err != nil {
+			return fmt.Errorf("failed to prepare dind container: %v", err)
+		}
+	}
+
 	environment := buildEntry.Environment
 
 	srcDir := buildEntry.SrcPath
@@ -151,6 +177,21 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 		dockerCommandOptions = append([]string{"--privileged"}, dockerCommandOptions...)
 	}
 
+	if dockerEnabled {
+		dockerCommandOptions = append(
+			[]string{
+				"--network", d.dind.network,
+				"-e", "DOCKER_TLS_CERTDIR=/certs",
+				"-e", "DOCKER_HOST=tcp://docker:2376",
+				"-e", "DOCKER_TLS_VERIFY=1",
+				"-e", "DOCKER_CERT_PATH=/certs/client",
+				"-e", fmt.Sprintf("SD_DIND_SHARE_PATH=%s", d.dind.shareVolumePath),
+				"-v", fmt.Sprintf("%s:/certs/client:ro", d.dind.volume),
+				"-v", fmt.Sprintf("%s:%s", d.dind.shareVolumeName, d.dind.shareVolumePath),
+			},
+			dockerCommandOptions...)
+	}
+
 	if d.buildUser != "" {
 		dockerCommandOptions = append([]string{fmt.Sprintf("-u%s", d.buildUser)}, dockerCommandOptions...)
 	}
@@ -181,6 +222,38 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 		if err != nil {
 			return fmt.Errorf("failed to run build container: %v", err)
 		}
+	}
+
+	return nil
+}
+
+func (d *docker) runDinD() error {
+	logrus.Infof("Pulling dind image from %s...", d.dind.image)
+	_, err := d.execDockerCommand("pull", d.dind.image)
+	if err != nil {
+		return fmt.Errorf("failed to pull user image %v", err)
+	}
+
+	if _, err := d.execDockerCommand([]string{"network", "create", d.dind.network}...); err != nil {
+		return fmt.Errorf("failed to create network: %v", err)
+	}
+
+	dockerCommandArgs := []string{"container", "run"}
+	dockerCommandOptions := []string{
+		"--rm",
+		"--privileged",
+		"--name", "sd-local-dind",
+		"-d",
+		"--network", d.dind.network,
+		"--network-alias", "docker",
+		"-e", "DOCKER_TLS_CERTDIR=/certs",
+		"-v", fmt.Sprintf("%s:/certs/client", d.dind.volume),
+		"-v", fmt.Sprintf("%s:/opt/sd_dind_share", d.dind.shareVolumeName),
+		d.dind.image,
+	}
+
+	if _, err := d.execDockerCommand(append(dockerCommandArgs, dockerCommandOptions...)...); err != nil {
+		return fmt.Errorf("failed to run dind container: %v", err)
 	}
 
 	return nil
@@ -267,6 +340,30 @@ func (d *docker) clean() {
 
 	if err != nil {
 		logrus.Warn(fmt.Errorf("failed to remove hab volume: %v", err))
+	}
+
+	_, err = d.execDockerCommand("kill", d.dind.container)
+
+	if err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove dind container: %v", err))
+	}
+
+	_, err = d.execDockerCommand("network", "rm", "--force", d.dind.network)
+
+	if err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
+	}
+
+	_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.volume)
+
+	if err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
+	}
+
+	_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.shareVolumeName)
+
+	if err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove dind share volume: %v", err))
 	}
 }
 

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// DinD has the information needed to start the dind-rootless container
 type DinD struct {
 	volume          string
 	shareVolumeName string

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -44,24 +44,25 @@ type launch struct {
 type Meta map[string]interface{}
 
 type buildEntry struct {
-	ID              int                 `json:"id"`
-	Environment     []map[string]string `json:"environment"`
-	EventID         int                 `json:"eventId"`
-	JobID           int                 `json:"jobId"`
-	ParentBuildID   []int               `json:"parentBuildId"`
-	Sha             string              `json:"sha"`
-	Meta            Meta                `json:"meta"`
-	Steps           []screwdriver.Step  `json:"steps"`
-	Image           string              `json:"-"`
-	JobName         string              `json:"-"`
-	ArtifactsPath   string              `json:"-"`
-	MemoryLimit     string              `json:"-"`
-	SrcPath         string              `json:"-"`
-	UseSudo         bool                `json:"-"`
-	InteractiveMode bool                `json:"-"`
-	SocketPath      string              `json:"-"`
-	UsePrivileged   bool                `json:"-"`
-	LocalVolumes    []string            `json:"-"`
+	ID              int                    `json:"id"`
+	Environment     []map[string]string    `json:"environment"`
+	EventID         int                    `json:"eventId"`
+	JobID           int                    `json:"jobId"`
+	ParentBuildID   []int                  `json:"parentBuildId"`
+	Sha             string                 `json:"sha"`
+	Meta            Meta                   `json:"meta"`
+	Annotations     map[string]interface{} `json:"annotations"`
+	Steps           []screwdriver.Step     `json:"steps"`
+	Image           string                 `json:"-"`
+	JobName         string                 `json:"-"`
+	ArtifactsPath   string                 `json:"-"`
+	MemoryLimit     string                 `json:"-"`
+	SrcPath         string                 `json:"-"`
+	UseSudo         bool                   `json:"-"`
+	InteractiveMode bool                   `json:"-"`
+	SocketPath      string                 `json:"-"`
+	UsePrivileged   bool                   `json:"-"`
+	LocalVolumes    []string               `json:"-"`
 }
 
 // Option is option for launch New
@@ -132,6 +133,7 @@ func createBuildEntry(option Option) buildEntry {
 		ParentBuildID:   []int{0},
 		Sha:             "dummy",
 		Meta:            option.Meta,
+		Annotations:     option.Job.Annotations,
 		Steps:           option.Job.Steps,
 		Image:           option.Job.Image,
 		JobName:         option.JobName,

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -30,6 +30,7 @@ func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 		ParentBuildID: []int{0},
 		Sha:           "dummy",
 		Meta:          Meta{},
+		Annotations:   map[string]interface{}{},
 		Steps:         job.Steps,
 		Image:         job.Image,
 		JobName:       "test",
@@ -49,6 +50,7 @@ func TestNew(t *testing.T) {
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 		job.Environment = append(job.Environment, map[string]string{"SD_ARTIFACTS_DIR": "/test/artifacts"})
+		job.Annotations = map[string]interface{}{}
 
 		config := config.Entry{
 			APIURL:   "http://api-test.screwdriver.cd",
@@ -81,6 +83,7 @@ func TestNew(t *testing.T) {
 	t.Run("success with default artifacts dir", func(t *testing.T) {
 		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
+		job.Annotations = map[string]interface{}{}
 		_ = json.Unmarshal(buf, &job)
 
 		config := config.Entry{

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -76,9 +76,10 @@ func (en *EnvVars) AppendAll(en2 map[string]string) {
 
 // Job is job entity struct
 type Job struct {
-	Steps       []Step  `json:"commands"`
-	Environment EnvVars `json:"environment"`
-	Image       string  `json:"image"`
+	Annotations map[string]interface{} `json:"annotations"`
+	Steps       []Step                 `json:"commands"`
+	Environment EnvVars                `json:"environment"`
+	Image       string                 `json:"image"`
 }
 
 type jobs map[string][]Job


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
I want to be able to debug builds locally using docker commands.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Add the feature to start the `dind-rootless` container if `screwdriver.cd/dockerEnabled: true` is set in the annotation of the job.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/2969

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
