### PR TITLE
fix(2969): Do not clear DinD images when DinD is not used

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -109,9 +109,7 @@ func (d *docker) setupBin() error {
 }
 
 func (d *docker) runBuild(buildEntry buildEntry) error {
-	dockerEnabled, _ := buildEntry.Annotations["screwdriver.cd/dockerEnabled"].(bool)
-
-	if dockerEnabled {
+	if d.dind.enabled {
 		if err := d.runDinD(); err != nil {
 			return fmt.Errorf("failed to prepare dind container: %v", err)
 		}
@@ -180,7 +178,7 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 		dockerCommandOptions = append([]string{"--privileged"}, dockerCommandOptions...)
 	}
 
-	if dockerEnabled {
+	if d.dind.enabled {
 		dockerCommandOptions = append(
 			[]string{
 				"--network", d.dind.network,

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -20,7 +20,7 @@ import (
 
 // DinD has the information needed to start the dind-rootless container
 type DinD struct {
-	enable          bool
+	enabled         bool
 	volume          string
 	shareVolumeName string
 	shareVolumePath string
@@ -59,7 +59,7 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
-func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, buildUser string, dindEnable bool) runner {
+func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, buildUser string, dindEnabled bool) runner {
 	return &docker{
 		volume:            "SD_LAUNCH_BIN",
 		habVolume:         "SD_LAUNCH_HAB",
@@ -75,7 +75,7 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 		localVolumes:      localVolumes,
 		buildUser:         buildUser,
 		dind: DinD{
-			enable:          dindEnable,
+			enabled:         dindEnabled,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",
@@ -345,7 +345,7 @@ func (d *docker) clean() {
 		logrus.Warn(fmt.Errorf("failed to remove hab volume: %v", err))
 	}
 
-	if d.dind.enable {
+	if d.dind.enabled {
 		_, err = d.execDockerCommand("kill", d.dind.container)
 
 		if err != nil {

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -20,6 +20,7 @@ import (
 
 // DinD has the information needed to start the dind-rootless container
 type DinD struct {
+	enable          bool
 	volume          string
 	shareVolumeName string
 	shareVolumePath string
@@ -58,7 +59,7 @@ const (
 	orgRepo = "sd-local/local-build"
 )
 
-func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, buildUser string) runner {
+func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode bool, socketPath string, flagVerbose bool, localVolumes []string, buildUser string, dindEnable bool) runner {
 	return &docker{
 		volume:            "SD_LAUNCH_BIN",
 		habVolume:         "SD_LAUNCH_HAB",
@@ -74,6 +75,7 @@ func newDocker(setupImage, setupImageVer string, useSudo bool, interactiveMode b
 		localVolumes:      localVolumes,
 		buildUser:         buildUser,
 		dind: DinD{
+			enable:          dindEnable,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",
@@ -343,28 +345,30 @@ func (d *docker) clean() {
 		logrus.Warn(fmt.Errorf("failed to remove hab volume: %v", err))
 	}
 
-	_, err = d.execDockerCommand("kill", d.dind.container)
+	if d.dind.enable {
+		_, err = d.execDockerCommand("kill", d.dind.container)
 
-	if err != nil {
-		logrus.Warn(fmt.Errorf("failed to remove dind container: %v", err))
-	}
+		if err != nil {
+			logrus.Warn(fmt.Errorf("failed to remove dind container: %v", err))
+		}
 
-	_, err = d.execDockerCommand("network", "rm", "--force", d.dind.network)
+		_, err = d.execDockerCommand("network", "rm", "--force", d.dind.network)
 
-	if err != nil {
-		logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
-	}
+		if err != nil {
+			logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
+		}
 
-	_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.volume)
+		_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.volume)
 
-	if err != nil {
-		logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
-	}
+		if err != nil {
+			logrus.Warn(fmt.Errorf("failed to remove dind volume: %v", err))
+		}
 
-	_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.shareVolumeName)
+		_, err = d.execDockerCommand("volume", "rm", "--force", d.dind.shareVolumeName)
 
-	if err != nil {
-		logrus.Warn(fmt.Errorf("failed to remove dind share volume: %v", err))
+		if err != nil {
+			logrus.Warn(fmt.Errorf("failed to remove dind share volume: %v", err))
+		}
 	}
 }
 

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -93,15 +93,6 @@ func TestSetupBin(t *testing.T) {
 		volume:            "SD_LAUNCH_BIN",
 		setupImage:        "launcher",
 		setupImageVersion: "latest",
-		dind: DinD{
-			enabled:         false,
-			volume:          "SD_DIND_CERT",
-			shareVolumeName: "SD_DIND_SHARE",
-			shareVolumePath: "/opt/sd_dind_share",
-			container:       "sd-local-dind",
-			network:         "sd-local-dind-bridge",
-			image:           "docker:23.0.1-dind-rootless",
-		},
 	}
 
 	testCase := []struct {

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -68,7 +68,7 @@ func TestNewDocker(t *testing.T) {
 			localVolumes:      []string{"path:path"},
 			buildUser:         "jithin",
 			dind: DinD{
-				enable:          true,
+				enabled:         true,
 				volume:          "SD_DIND_CERT",
 				shareVolumeName: "SD_DIND_SHARE",
 				shareVolumePath: "/opt/sd_dind_share",

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -94,7 +94,7 @@ func TestSetupBin(t *testing.T) {
 		setupImage:        "launcher",
 		setupImageVersion: "latest",
 		dind: DinD{
-			enabled:         false
+			enabled:         false,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",
@@ -169,7 +169,7 @@ func TestRunBuild(t *testing.T) {
 		setupImageVersion: "latest",
 		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 		dind: DinD{
-			enabled:         false
+			enabled:         false,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",
@@ -288,7 +288,7 @@ func TestRunBuildWithSudo(t *testing.T) {
 		useSudo:           true,
 		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 		dind: DinD{
-			enabled:         false
+			enabled:         false,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",
@@ -352,7 +352,7 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		interact:          &mockInteract{},
 		socketPath:        os.Getenv("SSH_AUTH_SOCK"),
 		dind: DinD{
-			enabled:         false
+			enabled:         false,
 			volume:          "SD_DIND_CERT",
 			shareVolumeName: "SD_DIND_SHARE",
 			shareVolumePath: "/opt/sd_dind_share",

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -68,7 +68,7 @@ func TestNewDocker(t *testing.T) {
 			localVolumes:      []string{"path:path"},
 			buildUser:         "jithin",
 			dind: DinD{
-				enable:          true,  
+				enable:          true,
 				volume:          "SD_DIND_CERT",
 				shareVolumeName: "SD_DIND_SHARE",
 				shareVolumePath: "/opt/sd_dind_share",

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -68,6 +68,7 @@ func TestNewDocker(t *testing.T) {
 			localVolumes:      []string{"path:path"},
 			buildUser:         "jithin",
 			dind: DinD{
+				enable:          true,  
 				volume:          "SD_DIND_CERT",
 				shareVolumeName: "SD_DIND_SHARE",
 				shareVolumePath: "/opt/sd_dind_share",
@@ -77,7 +78,7 @@ func TestNewDocker(t *testing.T) {
 			},
 		}
 
-		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"}, "jithin")
+		d := newDocker("launcher", "latest", false, false, "/auth.sock", false, []string{"path:path"}, "jithin", true)
 
 		assert.Equal(t, expected, d)
 	})

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -151,8 +151,9 @@ func createBuildEntry(option Option) buildEntry {
 // New creates new Launcher interface.
 func New(option Option) Launcher {
 	l := new(launch)
+	dindEnable, _ := option.Job.Annotations["screwdriver.cd/dockerEnabled"].(bool)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser, dindEnable)
 	l.buildEntry = createBuildEntry(option)
 
 	return l

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -151,9 +151,9 @@ func createBuildEntry(option Option) buildEntry {
 // New creates new Launcher interface.
 func New(option Option) Launcher {
 	l := new(launch)
-	dindEnable, _ := option.Job.Annotations["screwdriver.cd/dockerEnabled"].(bool)
+	dindEnabled, _ := option.Job.Annotations["screwdriver.cd/dockerEnabled"].(bool)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser, dindEnable)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser, dindEnabled)
 	l.buildEntry = createBuildEntry(option)
 
 	return l


### PR DESCRIPTION
## Context
Even when Dind is not used, it is still trying to clear the Dind image and generates a warning.
<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
We fix so that when Dind is not used, the process of clearing the Dind image is not performed.
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References
https://github.com/screwdriver-cd/screwdriver/issues/2969
<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
