### PR TITLE
fix(2983): replace deprecated usages of io/ioutil pkg

### DIFF
--- a/buildlog/buildlog_test.go
+++ b/buildlog/buildlog_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +47,7 @@ func write(tb testing.TB, filepath string, inputs []string) {
 
 func TestRun(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		tmpFile, err := ioutil.TempFile("", "")
+		tmpFile, err := os.CreateTemp("", "*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +82,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("success with long JSON output", func(t *testing.T) {
-		tmpFile, err := ioutil.TempFile("", "")
+		tmpFile, err := os.CreateTemp("", "*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +131,7 @@ func TestRun(t *testing.T) {
 		defer func() {
 			logrus.SetOutput(os.Stderr)
 		}()
-		tmpFile, err := ioutil.TempFile("", "")
+		tmpFile, err := os.CreateTemp("", "*")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,7 +198,7 @@ func TestStop(t *testing.T) {
 
 func TestNew(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		tmpFile, err := ioutil.TempFile("", "")
+		tmpFile, err := os.CreateTemp("", "*")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -112,7 +111,7 @@ func newBuildCmd() *cobra.Command {
 					return err
 				}
 
-				metaJSON, err = ioutil.ReadFile(absMetaFilePath)
+				metaJSON, err = os.ReadFile(absMetaFilePath)
 
 				if err != nil {
 					return fmt.Errorf("failed to read meta-file %s: %v", metaFilePath, err)

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +36,7 @@ func TestBuildCmd(t *testing.T) {
 
 		root := newBuildCmd()
 
-		dir, err := ioutil.TempDir("", "example")
+		dir, err := os.MkdirTemp("", "example")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -318,7 +317,7 @@ func TestConfigSave(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		actual, err := ioutil.ReadFile(cnfPath)
+		actual, err := os.ReadFile(cnfPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/screwdriver/screwdriver.go
+++ b/screwdriver/screwdriver.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -167,7 +167,7 @@ func (sd *sdAPI) jwt() (string, error) {
 }
 
 func readScrewdriverYAML(filePath string) (string, error) {
-	yaml, err := ioutil.ReadFile(filePath)
+	yaml, err := os.ReadFile(filePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read screwdriver.yaml: %v", err)
 	}


### PR DESCRIPTION
## Context
PR replaces the deprecated usage of the `io/ioutil` package.  
## Objective
Modernise the Go code of the repository.

## References
https://github.com/golang/go/issues/42025
https://github.com/golang/go/issues/40026
https://github.com/screwdriver-cd/screwdriver/issues/2983

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
