### PR TITLE
feat(72): Make it easy to execute commands in steps

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,11 @@
+version: 2
+
 brews:
-  - tap:
+  - repository:
       owner: screwdriver-cd
       name: sd-local
       branch: master
-    folder: Formula
+    directory: Formula
     homepage: "https://github.com/screwdriver-cd/sd-local"
     description: "Screwdriver local mode."
     commit_msg_template: "[skip ci] Brew formula update for {{ .ProjectName }} version {{ .Tag }}"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Global Flags:
   1. environment in a screwdriver.yaml
   1. defaultEnv (e.g.: `SD_TOKEN`, `SD_API_URL`)
 
+* You can execute step commands in interactive mode.
+
+```bash
+sd-local# sdrun <step name>
+foo
+```
+
 * You can use docker commands in the build to run containers, build images, etc.
   * Set `screwdriver.cd/dockerEnabled: true` in the job annotations.
 ```yaml

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -232,6 +232,10 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
+			if err := osMkdirAll(sdUtilsPath, 0777); err != nil {
+				return err
+			}
+
 			loggerDone = make(chan struct{})
 			logger, err := buildLogNew(filepath.Join(artifactsPath, launch.LogFile), os.Stdout, loggerDone)
 			if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,6 +28,7 @@ var (
 	buildLogNew     = buildlog.New
 	launchNew       = launch.New
 	artifactsDir    = launch.ArtifactsDir
+	stepsDir        = launch.StepsDir
 	memory          = ""
 	scmNew          = scm.New
 	osMkdirAll      = os.MkdirAll
@@ -226,6 +227,11 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
+			stepsPath, err := filepath.Abs(stepsDir)
+			if err != nil {
+				return err
+			}
+
 			loggerDone = make(chan struct{})
 			logger, err := buildLogNew(filepath.Join(artifactsPath, launch.LogFile), os.Stdout, loggerDone)
 			if err != nil {
@@ -239,6 +245,7 @@ func newBuildCmd() *cobra.Command {
 				JobName:         jobName,
 				JWT:             api.JWT(),
 				ArtifactsPath:   artifactsPath,
+				StepsPath:       stepsPath,
 				Memory:          memory,
 				SrcPath:         srcPath,
 				OptionEnv:       optionEnv,
@@ -277,6 +284,12 @@ func newBuildCmd() *cobra.Command {
 		"artifacts-dir",
 		launch.ArtifactsDir,
 		"Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR.")
+
+	buildCmd.Flags().StringVar(
+		&stepsDir,
+		"steps-dir",
+		launch.StepsDir,
+		"Path to the host side directory that is created to mount step script files when using interactive mode.")
 
 	buildCmd.Flags().StringVarP(
 		&memory,

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,7 +28,7 @@ var (
 	buildLogNew     = buildlog.New
 	launchNew       = launch.New
 	artifactsDir    = launch.ArtifactsDir
-	stepsDir        = launch.StepsDir
+	sdUtilsDir      = launch.SdUtilsDir
 	memory          = ""
 	scmNew          = scm.New
 	osMkdirAll      = os.MkdirAll
@@ -227,7 +227,7 @@ func newBuildCmd() *cobra.Command {
 				return err
 			}
 
-			stepsPath, err := filepath.Abs(stepsDir)
+			sdUtilsPath, err := filepath.Abs(sdUtilsDir)
 			if err != nil {
 				return err
 			}
@@ -245,7 +245,7 @@ func newBuildCmd() *cobra.Command {
 				JobName:         jobName,
 				JWT:             api.JWT(),
 				ArtifactsPath:   artifactsPath,
-				StepsPath:       stepsPath,
+				SdUtilsPath:     sdUtilsPath,
 				Memory:          memory,
 				SrcPath:         srcPath,
 				OptionEnv:       optionEnv,
@@ -286,10 +286,10 @@ func newBuildCmd() *cobra.Command {
 		"Path to the host side directory which is mounted into $SD_ARTIFACTS_DIR.")
 
 	buildCmd.Flags().StringVar(
-		&stepsDir,
-		"steps-dir",
-		launch.StepsDir,
-		"Path to the host side directory that is created to mount step script files when using interactive mode.")
+		&sdUtilsDir,
+		"utils-dir",
+		launch.SdUtilsDir,
+		"Path to the host side directory that is created to mount utility files for interactive mode.")
 
 	buildCmd.Flags().StringVarP(
 		&memory,

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -43,7 +43,7 @@ func TestBuildCmd(t *testing.T) {
 
 		defer os.RemoveAll(dir)
 
-		artifactsDir := filepath.Join(dir, "sd-artifacts")
+		artifactsDir := filepath.Join(dir, "test-artifacts")
 
 		root.SetArgs([]string{"test", "--artifacts-dir", artifactsDir})
 		buf := bytes.NewBuffer(nil)
@@ -54,6 +54,36 @@ func TestBuildCmd(t *testing.T) {
 		assert.Nil(t, err)
 
 		_, err = os.Stat(artifactsDir)
+		assert.Nil(t, err)
+	})
+
+	t.Run("Success build cmd with --utils-dir", func(t *testing.T) {
+		defFunc := osMkdirAll
+		osMkdirAll = os.MkdirAll
+		defer func() {
+			osMkdirAll = defFunc
+		}()
+
+		root := newBuildCmd()
+
+		dir, err := os.MkdirTemp("", "example")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		defer os.RemoveAll(dir)
+
+		sdUtilsDir := filepath.Join(dir, "test-utils")
+
+		root.SetArgs([]string{"test", "--utils-dir", sdUtilsDir})
+		buf := bytes.NewBuffer(nil)
+		root.SetOut(buf)
+		err = root.Execute()
+		want := ""
+		assert.Equal(t, want, buf.String())
+		assert.Nil(t, err)
+
+		_, err = os.Stat(sdUtilsDir)
 		assert.Nil(t, err)
 	})
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,9 +60,9 @@ Flags:
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
-      --steps-dir string       Path to the host side directory that is created to mount step script files when using interactive mode. (default ".sd-steps")
       --sudo                   Use sudo command for container runtime.
   -u, --user string            Change default build user. Default value is from container in use.
+      --utils-dir string       Path to the host side directory that is created to mount utility files for interactive mode. (default ".sd-utils")
       --vol strings            Volumes to mount into build container.
 
 `, defaultSocketPath)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -60,6 +60,7 @@ Flags:
       --src-url string         Specify the source url to build.
                                ex) git@github.com:<org>/<repo>.git[#<branch>]
                                    https://github.com/<org>/<repo>.git[#<branch>]
+      --steps-dir string       Path to the host side directory that is created to mount step script files when using interactive mode. (default ".sd-steps")
       --sudo                   Use sudo command for container runtime.
   -u, --user string            Change default build user. Default value is from container in use.
       --vol strings            Volumes to mount into build container.

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -126,7 +126,7 @@ func setupInteractiveMode(buildEntry *buildEntry) error {
 		return err
 	}
 
-	if err := os.MkdirAll(fmt.Sprintf("%s/bin", stepsPath), 0777); err != nil {
+	if err := os.MkdirAll(fmt.Sprintf("%s/.bin", stepsPath), 0777); err != nil {
 		return err
 	}
 
@@ -143,7 +143,7 @@ if [ "${step_name}" = "" ]; then echo "${step_list}";
 else . "${SD_STEPS_DIR}/${step_name}"; fi
 `, shellBin)
 
-	if err := os.WriteFile(fmt.Sprintf("%s/bin/sd-run", stepsPath), []byte(sdRunShell), 0755); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("%s/.bin/sd-run", stepsPath), []byte(sdRunShell), 0755); err != nil {
 		return err
 	}
 
@@ -278,8 +278,8 @@ func (d *docker) runBuild(buildEntry buildEntry) error {
 			{".", "/tmp/sd-local.env"},
 			{"set", "+a"},
 			{"export", "PS1='sd-local# '"},
+			{"sdrun() { . /$SD_STEPS_DIR/.bin/sd-run $@; }"},
 			{"cd", "$SD_CHECKOUT_DIR"},
-			{"sdrun() { . /$SD_STEPS_DIR/bin/sd-run $@; }"},
 		}
 
 		if err := d.attachDockerCommand(attachCommands, commands); err != nil {

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -55,6 +55,8 @@ const (
 	ArtifactsDir = "sd-artifacts"
 	// LogFile is default logfile name for build log
 	LogFile = "builds.log"
+	// StepsDir is default directory name for step script files
+	StepsDir = ".sd-steps"
 	// The definition of "ScmHost" and "OrgRepo" is in "PipelineFromID" of "screwdriver/screwdriver_local.go"
 	scmHost = "screwdriver.cd"
 	orgRepo = "sd-local/local-build"

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -419,10 +419,8 @@ func (d *docker) clean() {
 		logrus.Warn(fmt.Errorf("failed to remove hab volume: %v", err))
 	}
 
-	if d.interactiveMode {
-		if err := os.RemoveAll(d.sdUtilsPath); err != nil {
-			logrus.Warn(fmt.Errorf("failed to remove sd-utils directory %s: %v", d.sdUtilsPath, err))
-		}
+	if err := os.RemoveAll(d.sdUtilsPath); err != nil {
+		logrus.Warn(fmt.Errorf("failed to remove sd-utils directory %s: %v", d.sdUtilsPath, err))
 	}
 
 	if d.dind.enabled {

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -420,14 +420,8 @@ func (d *docker) clean() {
 	}
 
 	if d.interactiveMode {
-		if sdUtilsPath, err := filepath.Abs(d.sdUtilsPath); err == nil {
-			err := os.RemoveAll(sdUtilsPath)
-
-			if err != nil {
-				logrus.Warn(fmt.Errorf("failed to remove sd-utils directory %s: %v", sdUtilsPath, err))
-			}
-		} else {
-			logrus.Warn(fmt.Errorf("failed to parse sd-utils directory %s: %v", sdUtilsPath, err))
+		if err := os.RemoveAll(d.sdUtilsPath); err != nil {
+			logrus.Warn(fmt.Errorf("failed to remove sd-utils directory %s: %v", d.sdUtilsPath, err))
 		}
 	}
 

--- a/launch/docker.go
+++ b/launch/docker.go
@@ -47,8 +47,12 @@ type docker struct {
 	dind              DinD
 }
 
-var _ runner = (*docker)(nil)
-var execCommand = exec.Command
+var (
+	_           runner = (*docker)(nil)
+	execCommand        = exec.Command
+	osMkdirAll         = os.MkdirAll
+	osWriteFile        = os.WriteFile
+)
 
 const (
 	// ArtifactsDir is default artifact directory name
@@ -122,11 +126,11 @@ func setupInteractiveMode(buildEntry *buildEntry) error {
 		return err
 	}
 
-	if err := os.MkdirAll(stepsPath, 0777); err != nil {
+	if err := osMkdirAll(stepsPath, 0777); err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(fmt.Sprintf("%s/.bin", stepsPath), 0777); err != nil {
+	if err := osMkdirAll(fmt.Sprintf("%s/.bin", stepsPath), 0777); err != nil {
 		return err
 	}
 
@@ -143,12 +147,12 @@ if [ "${step_name}" = "" ]; then echo "${step_list}";
 else . "${SD_STEPS_DIR}/${step_name}"; fi
 `, shellBin)
 
-	if err := os.WriteFile(fmt.Sprintf("%s/.bin/sd-run", stepsPath), []byte(sdRunShell), 0755); err != nil {
+	if err := osWriteFile(fmt.Sprintf("%s/.bin/sd-run", stepsPath), []byte(sdRunShell), 0755); err != nil {
 		return err
 	}
 
 	for _, step := range buildEntry.Steps {
-		if err := os.WriteFile(fmt.Sprintf("%s/%s", stepsPath, step.Name), []byte("#!"+shellBin+" -e\n"+step.Command), 0755); err != nil {
+		if err := osWriteFile(fmt.Sprintf("%s/%s", stepsPath, step.Name), []byte("#!"+shellBin+" -e\n"+step.Command), 0755); err != nil {
 			return err
 		}
 	}

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -211,7 +211,7 @@ func TestRunBuild(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("ocker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -454,13 +454,13 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -itd -v sd-steps/:/test/sd-steps --pull never node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -itd -v sd-utils/:/test/sd-utils --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach "},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB -itd -v sd-steps/:/test/sd-steps --pull never node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB -itd -v sd-utils/:/test/sd-utils --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach SUCCESS_RUN_BUILD_INTERACT"},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -181,12 +181,12 @@ func TestRunBuild(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("ocker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run -m2GB --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -245,7 +245,7 @@ func TestRunBuildWithDind(t *testing.T) {
 				"docker network create sd-local-dind-bridge",
 				"docker container run --rm --privileged --pull never --name sd-local-dind -d --network sd-local-dind-bridge --network-alias docker -e DOCKER_TLS_CERTDIR=/certs -v SD_DIND_CERT:/certs/client -v SD_DIND_SHARE:/opt/sd_dind_share docker:23.0.1-dind-rootless",
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.Annotations["screwdriver.cd/dockerEnabled"] = true
 			})},
@@ -301,7 +301,7 @@ func TestRunBuildWithNoImagePull(t *testing.T) {
 			[]string{
 				"docker network create sd-local-dind-bridge",
 				"docker container run --rm --privileged --pull never --name sd-local-dind -d --network sd-local-dind-bridge --network-alias docker -e DOCKER_TLS_CERTDIR=/certs -v SD_DIND_CERT:/certs/client -v SD_DIND_SHARE:/opt/sd_dind_share docker:23.0.1-dind-rootless",
-				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.Annotations["screwdriver.cd/dockerEnabled"] = true
 			})},
@@ -356,12 +356,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -420,13 +420,13 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -itd --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -itd --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach "},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run -m2GB -itd --rm --pull never -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB -itd --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach SUCCESS_RUN_BUILD_INTERACT"},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"

--- a/launch/docker_test.go
+++ b/launch/docker_test.go
@@ -209,12 +209,12 @@ func TestRunBuild(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("ocker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("ocker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD", nil,
 			[]string{
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -273,7 +273,7 @@ func TestRunBuildWithDind(t *testing.T) {
 				"docker network create sd-local-dind-bridge",
 				"docker container run --rm --privileged --pull never --name sd-local-dind -d --network sd-local-dind-bridge --network-alias docker -e DOCKER_TLS_CERTDIR=/certs -v SD_DIND_CERT:/certs/client -v SD_DIND_SHARE:/opt/sd_dind_share docker:23.0.1-dind-rootless",
 				"docker pull node:12",
-				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.Annotations["screwdriver.cd/dockerEnabled"] = true
 			})},
@@ -329,7 +329,7 @@ func TestRunBuildWithNoImagePull(t *testing.T) {
 			[]string{
 				"docker network create sd-local-dind-bridge",
 				"docker container run --rm --privileged --pull never --name sd-local-dind -d --network sd-local-dind-bridge --network-alias docker -e DOCKER_TLS_CERTDIR=/certs -v SD_DIND_CERT:/certs/client -v SD_DIND_SHARE:/opt/sd_dind_share docker:23.0.1-dind-rootless",
-				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("docker container run --network %s -e DOCKER_TLS_CERTDIR=/certs -e DOCKER_HOST=tcp://docker:2376 -e DOCKER_TLS_VERIFY=1 -e DOCKER_CERT_PATH=/certs/client -e SD_DIND_SHARE_PATH=%s -v %s:/certs/client:ro -v %s:%s --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.dind.network, d.dind.shareVolumePath, d.dind.volume, d.dind.shareVolumeName, d.dind.shareVolumePath, d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.Annotations["screwdriver.cd/dockerEnabled"] = true
 			})},
@@ -384,12 +384,12 @@ func TestRunBuildWithSudo(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_SUDO", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB --pull never node:12 /opt/sd/local_run.sh ", d.volume, d.habVolume, sshSocket)},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"
 			})},
@@ -454,13 +454,13 @@ func TestRunBuildWithInteractiveMode(t *testing.T) {
 		{"success", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -itd --pull never node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -itd -v sd-steps/:/test/sd-steps --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach "},
 			newBuildEntry()},
 		{"success with memory limit", "SUCCESS_RUN_BUILD_INTERACT", nil,
 			[]string{
 				"sudo docker pull node:12",
-				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v sd-steps/:/test/sd-steps -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB -itd --pull never node:12", d.volume, d.habVolume, sshSocket),
+				fmt.Sprintf("sudo docker container run --rm --entrypoint /bin/sh -e SSH_AUTH_SOCK=/tmp/auth.sock -v /:/sd/workspace/src/screwdriver.cd/sd-local/local-build -v sd-artifacts/:/test/artifacts -v %s:/opt/sd -v %s:/opt/sd/hab -v %s -m2GB -itd -v sd-steps/:/test/sd-steps --pull never node:12", d.volume, d.habVolume, sshSocket),
 				"sudo docker attach SUCCESS_RUN_BUILD_INTERACT"},
 			newBuildEntry(func(b *buildEntry) {
 				b.MemoryLimit = "2GB"

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -56,7 +56,7 @@ type buildEntry struct {
 	Image           string                 `json:"-"`
 	JobName         string                 `json:"-"`
 	ArtifactsPath   string                 `json:"-"`
-	StepsPath       string                 `json:"-"`
+	SdUtilsPath     string                 `json:"-"`
 	MemoryLimit     string                 `json:"-"`
 	SrcPath         string                 `json:"-"`
 	UseSudo         bool                   `json:"-"`
@@ -73,7 +73,7 @@ type Option struct {
 	JobName         string
 	JWT             string
 	ArtifactsPath   string
-	StepsPath       string
+	SdUtilsPath     string
 	Memory          string
 	SrcPath         string
 	OptionEnv       screwdriver.EnvVars
@@ -89,8 +89,8 @@ type Option struct {
 }
 
 const (
-	defaultArtDir   = "/sd/workspace/artifacts"
-	defaultStepsDir = "/sd/workspace/sd-steps"
+	defaultArtDir     = "/sd/workspace/artifacts"
+	defaultSdUtilsDir = "/sd/workspace/sd-utils"
 )
 
 // DefaultSocketPath is a socket path on the localhost to bring in the build container.
@@ -124,7 +124,7 @@ func createBuildEntry(option Option) buildEntry {
 		logrus.Warn("SD_STORE_URL is invalid. It may cause errors")
 	}
 
-	env := []map[string]string{{"SD_TOKEN": option.JWT}, {"SD_ARTIFACTS_DIR": defaultArtDir}, {"SD_STEPS_DIR": defaultStepsDir}, {"SD_API_URL": apiURL}, {"SD_STORE_URL": storeURL}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}}
+	env := []map[string]string{{"SD_TOKEN": option.JWT}, {"SD_ARTIFACTS_DIR": defaultArtDir}, {"SD_UTILS_DIR": defaultSdUtilsDir}, {"SD_API_URL": apiURL}, {"SD_STORE_URL": storeURL}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}}
 
 	env = append(env, option.Job.Environment...)
 	env = append(env, option.OptionEnv...)
@@ -142,7 +142,7 @@ func createBuildEntry(option Option) buildEntry {
 		Image:           option.Job.Image,
 		JobName:         option.JobName,
 		ArtifactsPath:   option.ArtifactsPath,
-		StepsPath:       option.StepsPath,
+		SdUtilsPath:     option.SdUtilsPath,
 		MemoryLimit:     option.Memory,
 		SrcPath:         option.SrcPath,
 		UseSudo:         option.UseSudo,

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -56,6 +56,7 @@ type buildEntry struct {
 	Image           string                 `json:"-"`
 	JobName         string                 `json:"-"`
 	ArtifactsPath   string                 `json:"-"`
+	StepsPath       string                 `json:"-"`
 	MemoryLimit     string                 `json:"-"`
 	SrcPath         string                 `json:"-"`
 	UseSudo         bool                   `json:"-"`
@@ -72,6 +73,7 @@ type Option struct {
 	JobName         string
 	JWT             string
 	ArtifactsPath   string
+	StepsPath       string
 	Memory          string
 	SrcPath         string
 	OptionEnv       screwdriver.EnvVars
@@ -87,7 +89,8 @@ type Option struct {
 }
 
 const (
-	defaultArtDir = "/sd/workspace/artifacts"
+	defaultArtDir   = "/sd/workspace/artifacts"
+	defaultStepsDir = "/sd/workspace/sd-steps"
 )
 
 // DefaultSocketPath is a socket path on the localhost to bring in the build container.
@@ -121,7 +124,7 @@ func createBuildEntry(option Option) buildEntry {
 		logrus.Warn("SD_STORE_URL is invalid. It may cause errors")
 	}
 
-	env := []map[string]string{{"SD_TOKEN": option.JWT}, {"SD_ARTIFACTS_DIR": defaultArtDir}, {"SD_API_URL": apiURL}, {"SD_STORE_URL": storeURL}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}}
+	env := []map[string]string{{"SD_TOKEN": option.JWT}, {"SD_ARTIFACTS_DIR": defaultArtDir}, {"SD_STEPS_DIR": defaultStepsDir}, {"SD_API_URL": apiURL}, {"SD_STORE_URL": storeURL}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}}
 
 	env = append(env, option.Job.Environment...)
 	env = append(env, option.OptionEnv...)
@@ -139,6 +142,7 @@ func createBuildEntry(option Option) buildEntry {
 		Image:           option.Job.Image,
 		JobName:         option.JobName,
 		ArtifactsPath:   option.ArtifactsPath,
+		StepsPath:       option.StepsPath,
 		MemoryLimit:     option.Memory,
 		SrcPath:         option.SrcPath,
 		UseSudo:         option.UseSudo,

--- a/launch/launch.go
+++ b/launch/launch.go
@@ -56,7 +56,6 @@ type buildEntry struct {
 	Image           string                 `json:"-"`
 	JobName         string                 `json:"-"`
 	ArtifactsPath   string                 `json:"-"`
-	SdUtilsPath     string                 `json:"-"`
 	MemoryLimit     string                 `json:"-"`
 	SrcPath         string                 `json:"-"`
 	UseSudo         bool                   `json:"-"`
@@ -142,7 +141,6 @@ func createBuildEntry(option Option) buildEntry {
 		Image:           option.Job.Image,
 		JobName:         option.JobName,
 		ArtifactsPath:   option.ArtifactsPath,
-		SdUtilsPath:     option.SdUtilsPath,
 		MemoryLimit:     option.Memory,
 		SrcPath:         option.SrcPath,
 		UseSudo:         option.UseSudo,
@@ -158,7 +156,7 @@ func New(option Option) Launcher {
 	l := new(launch)
 	dindEnabled, _ := option.Job.Annotations["screwdriver.cd/dockerEnabled"].(bool)
 
-	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser, option.NoImagePull, dindEnabled)
+	l.runner = newDocker(option.Entry.Launcher.Image, option.Entry.Launcher.Version, option.UseSudo, option.InteractiveMode, option.SdUtilsPath, option.SocketPath, option.FlagVerbose, option.LocalVolumes, option.BuildUser, option.NoImagePull, dindEnabled)
 	l.buildEntry = createBuildEntry(option)
 
 	return l

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -3,7 +3,6 @@ package launch
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,7 +17,7 @@ import (
 var testDir string = "./testdata"
 
 func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
-	buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+	buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 	job := screwdriver.Job{}
 	_ = json.Unmarshal(buf, &job)
 
@@ -143,7 +142,7 @@ func (m *mockRunner) kill(os.Signal) {
 
 func TestRun(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
@@ -169,7 +168,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("failure in lookPath", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
@@ -195,7 +194,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("failure in SetupBin", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
@@ -221,7 +220,7 @@ func TestRun(t *testing.T) {
 	})
 
 	t.Run("failure in RunBuild", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
@@ -249,7 +248,7 @@ func TestRun(t *testing.T) {
 
 func TestKill(t *testing.T) {
 	t.Run("success to call kill", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 
@@ -268,7 +267,7 @@ func TestKill(t *testing.T) {
 
 func TestClean(t *testing.T) {
 	t.Run("success to call clean", func(t *testing.T) {
-		buf, _ := ioutil.ReadFile(filepath.Join(testDir, "job.json"))
+		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
 

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -23,7 +23,7 @@ func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 
 	b := buildEntry{
 		ID:            0,
-		Environment:   []map[string]string{{"SD_TOKEN": "testjwt"}, {"SD_ARTIFACTS_DIR": "/test/artifacts"}, {"SD_STEPS_DIR": "/test/sd-steps"}, {"SD_API_URL": "http://api-test.screwdriver.cd/v4"}, {"SD_STORE_URL": "http://store-test.screwdriver.cd/v1"}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}, {"FOO": "foo"}},
+		Environment:   []map[string]string{{"SD_TOKEN": "testjwt"}, {"SD_ARTIFACTS_DIR": "/test/artifacts"}, {"SD_UTILS_DIR": "/test/sd-utils"}, {"SD_API_URL": "http://api-test.screwdriver.cd/v4"}, {"SD_STORE_URL": "http://store-test.screwdriver.cd/v1"}, {"SD_BASE_COMMAND_PATH": "/sd/commands/"}, {"FOO": "foo"}},
 		EventID:       0,
 		JobID:         0,
 		ParentBuildID: []int{0},
@@ -34,7 +34,7 @@ func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 		Image:         job.Image,
 		JobName:       "test",
 		ArtifactsPath: "sd-artifacts",
-		StepsPath:     "sd-steps",
+		SdUtilsPath:   "sd-utils",
 	}
 
 	for _, option := range options {
@@ -45,11 +45,11 @@ func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 }
 
 func TestNew(t *testing.T) {
-	t.Run("success with custom artifacts dir and steps dir", func(t *testing.T) {
+	t.Run("success with custom artifacts dir and sd-utils dir", func(t *testing.T) {
 		buf, _ := os.ReadFile(filepath.Join(testDir, "job.json"))
 		job := screwdriver.Job{}
 		_ = json.Unmarshal(buf, &job)
-		job.Environment = append(job.Environment, map[string]string{"SD_ARTIFACTS_DIR": "/test/artifacts", "SD_STEPS_DIR": "/test/sd-steps"})
+		job.Environment = append(job.Environment, map[string]string{"SD_ARTIFACTS_DIR": "/test/artifacts", "SD_UTILS_DIR": "/test/sd-utils"})
 		job.Annotations = map[string]interface{}{}
 
 		config := config.Entry{
@@ -61,8 +61,8 @@ func TestNew(t *testing.T) {
 
 		expectedBuildEntry := newBuildEntry()
 		expectedBuildEntry.Environment[1] = map[string]string{"SD_ARTIFACTS_DIR": "/sd/workspace/artifacts"}
-		expectedBuildEntry.Environment[2] = map[string]string{"SD_STEPS_DIR": "/sd/workspace/sd-steps"}
-		expectedBuildEntry.Environment = append(expectedBuildEntry.Environment, map[string]string{"SD_ARTIFACTS_DIR": "/test/artifacts", "SD_STEPS_DIR": "/test/sd-steps"})
+		expectedBuildEntry.Environment[2] = map[string]string{"SD_UTILS_DIR": "/sd/workspace/sd-utils"}
+		expectedBuildEntry.Environment = append(expectedBuildEntry.Environment, map[string]string{"SD_ARTIFACTS_DIR": "/test/artifacts", "SD_UTILS_DIR": "/test/sd-utils"})
 		expectedBuildEntry.SrcPath = "/test/sd-local/build/repo"
 
 		option := Option{
@@ -71,7 +71,7 @@ func TestNew(t *testing.T) {
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
-			StepsPath:     "sd-steps",
+			SdUtilsPath:   "sd-utils",
 			SrcPath:       "/test/sd-local/build/repo",
 			Meta:          Meta{},
 		}
@@ -98,7 +98,7 @@ func TestNew(t *testing.T) {
 		expectedBuildEntry := newBuildEntry()
 		// expectedBuildEntry.Environment[1] corresponds to SD_ARTIFACTS_DIR
 		expectedBuildEntry.Environment[1] = map[string]string{"SD_ARTIFACTS_DIR": "/sd/workspace/artifacts"}
-		expectedBuildEntry.Environment[2] = map[string]string{"SD_STEPS_DIR": "/sd/workspace/sd-steps"}
+		expectedBuildEntry.Environment[2] = map[string]string{"SD_UTILS_DIR": "/sd/workspace/sd-utils"}
 
 		option := Option{
 			Job:           job,
@@ -106,7 +106,7 @@ func TestNew(t *testing.T) {
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
-			StepsPath:     "sd-steps",
+			SdUtilsPath:   "sd-utils",
 			Meta:          Meta{},
 		}
 

--- a/launch/launch_test.go
+++ b/launch/launch_test.go
@@ -34,7 +34,6 @@ func newBuildEntry(options ...func(b *buildEntry)) buildEntry {
 		Image:         job.Image,
 		JobName:       "test",
 		ArtifactsPath: "sd-artifacts",
-		SdUtilsPath:   "sd-utils",
 	}
 
 	for _, option := range options {
@@ -71,7 +70,7 @@ func TestNew(t *testing.T) {
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
-			SdUtilsPath:   "sd-utils",
+			SdUtilsPath:   ".sd-utils",
 			SrcPath:       "/test/sd-local/build/repo",
 			Meta:          Meta{},
 		}
@@ -106,7 +105,7 @@ func TestNew(t *testing.T) {
 			JobName:       "test",
 			JWT:           "testjwt",
 			ArtifactsPath: "sd-artifacts",
-			SdUtilsPath:   "sd-utils",
+			SdUtilsPath:   ".sd-utils",
 			Meta:          Meta{},
 		}
 

--- a/screwdriver/screwdriver_test.go
+++ b/screwdriver/screwdriver_test.go
@@ -2,9 +2,9 @@ package screwdriver
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -50,7 +50,7 @@ func TestJob(t *testing.T) {
 			w.WriteHeader(200)
 			w.Header().Set("Content-Type", "application/json")
 
-			testJSON, err := ioutil.ReadFile(filepath.Join(testDir, "validatedSuccess.json"))
+			testJSON, err := os.ReadFile(filepath.Join(testDir, "validatedSuccess.json"))
 			assert.Nil(t, err)
 			fmt.Fprintln(w, string(testJSON))
 		}))
@@ -177,7 +177,7 @@ func TestJob(t *testing.T) {
 			w.WriteHeader(200)
 			w.Header().Set("Content-Type", "application/json")
 
-			testJSON, err := ioutil.ReadFile(filepath.Join(testDir, "validatedFailed.json"))
+			testJSON, err := os.ReadFile(filepath.Join(testDir, "validatedFailed.json"))
 			assert.Nil(t, err)
 
 			fmt.Fprintln(w, string(testJSON))
@@ -202,7 +202,7 @@ func TestJob(t *testing.T) {
 			w.WriteHeader(200)
 			w.Header().Set("Content-Type", "application/json")
 
-			testJSON, err := ioutil.ReadFile(filepath.Join(testDir, "validatedSuccess.json"))
+			testJSON, err := os.ReadFile(filepath.Join(testDir, "validatedSuccess.json"))
 			assert.Nil(t, err)
 			fmt.Fprintln(w, string(testJSON))
 		}))


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

We can debug build in interactive mode, but executing commands of steps is a little difficult.
We need to copy and paste to run commands of each steps.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Create utils to execute step commands in interactive mode.

e.g.
```bash
$ sd-local build -i test

sd-local# sdrun <step name>
foo
```

Utils are created in local `.sd-utils` directory and this directory is mounted on `/sd/workspace/sd-utils` in build container.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issues
- https://github.com/screwdriver-cd/sd-local/issues/72

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
