### PR TITLE
feat(72): fix to output step file in interactive mode

### DIFF
--- a/launch/docker.go
+++ b/launch/docker.go
@@ -198,7 +198,11 @@ func (d *docker) setupInteractiveMode(buildEntry *buildEntry) error {
 	}
 
 	for _, step := range buildEntry.Steps {
-		if err := osWriteFile(fmt.Sprintf("%s/steps/%s", sdUtilsPath, step.Name), []byte("#!"+shellBin+" -e\n"+step.Command), 0755); err != nil {
+		stepCommand := "#!" + shellBin + " -e\n" + step.Command
+		if !strings.HasSuffix(step.Command, "\n") {
+			stepCommand += "\n"
+		}
+		if err := osWriteFile(fmt.Sprintf("%s/steps/%s", sdUtilsPath, step.Name), []byte(stepCommand), 0755); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
fix (https://github.com/screwdriver-cd/sd-local/pull/96)
When writing a step file, a single-line step does not have a line break at the end, so when the step is executed, the execution result is displayed starting from the continuation of the step contents.
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
fix the results of a single-line step execution to be displayed starting with a new line.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/sd-local/issues/72
https://github.com/screwdriver-cd/sd-local/pull/96

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
